### PR TITLE
Improve pydantic error messages

### DIFF
--- a/sphinx_js/pydantic_typedoc.py
+++ b/sphinx_js/pydantic_typedoc.py
@@ -1,7 +1,7 @@
 from inspect import isclass
 from typing import Annotated, Any, Literal, Optional
 
-from pydantic import BaseConfig, BaseModel, Field
+from pydantic import BaseConfig, BaseModel, Field, ValidationError
 
 
 class Source(BaseModel):
@@ -202,3 +202,77 @@ IndexType = Node | Root | Signature | Param
 for cls in list(globals().values()):
     if isclass(cls) and issubclass(cls, BaseModel):
         cls.update_forward_refs()
+
+
+# Fix error messages
+#
+# The Pydantic error messages tend to contain TONS of irrelevant stuff. This
+# deletes the useless stuff and adds important context.
+
+discriminators = ["type", "kindString"]
+classesByDiscriminator: dict[str, dict[str, type[BaseModel]]] = {
+    disc: {} for disc in discriminators
+}
+
+for cls in list(globals().values()):
+    if not isclass(cls) or not issubclass(cls, BaseModel):
+        continue
+    for disc in discriminators:
+        if disc not in cls.__annotations__:
+            continue
+        ann = cls.__annotations__[disc]
+        if getattr(ann, "__name__", None) != "Literal":
+            continue
+        for arg in ann.__args__:
+            classesByDiscriminator[disc][arg] = cls
+
+
+def parse(json: dict[str, Any]) -> Root:
+    try:
+        return Root.parse_obj(json)
+    except ValidationError as exc:
+        from pprint import pprint
+
+        s = sorted(
+            set(e["loc"][:-1] for e in exc.errors()), key=lambda loc: (-len(loc), loc)
+        )
+        handled = set()
+        errors = []
+        for loc in s:
+            if loc in handled:
+                continue
+            # Add all prefixes of the current loc to handled
+            for i in range(len(s)):
+                handled.add(loc[:i])
+
+            # follow path to get problematic subobject
+            o = json
+            for a in loc:
+                o = o[a]  # type: ignore[index]
+
+            # Work out the discriminator and use it to look up the appropriate class
+            for disc in discriminators:
+                if disc not in o:
+                    continue
+                if o[disc] not in classesByDiscriminator[disc]:
+                    continue
+                c = classesByDiscriminator[disc][o[disc]]
+                try:
+                    c.parse_obj(o)
+                except ValidationError as e:
+                    errs = e.errors()
+
+                for err in errs:
+                    # Extend the loc so that it is relative to the top level object
+                    err["loc"] = loc + err["loc"]
+                    err["msg"] += "\n" + f"  Discriminator: {disc} = {o[disc]}\n"
+                    print("\n")
+                    print("loc:", err["loc"])
+                    print("msg:", err["msg"])
+                    print("obj:")
+                    pprint(o, depth=1)
+                    print("\n")
+                errors.extend(errs)
+
+        exc._error_cache = errors
+        raise

--- a/sphinx_js/pydantic_typedoc.py
+++ b/sphinx_js/pydantic_typedoc.py
@@ -204,12 +204,20 @@ for cls in list(globals().values()):
         cls.update_forward_refs()
 
 
+def parse(json: dict[str, Any]) -> Root:
+    try:
+        return Root.parse_obj(json)
+    except ValidationError as exc:
+        fix_exc_errors(json, exc)
+        raise
+
+
 # Fix error messages
 #
 # The Pydantic error messages tend to contain TONS of irrelevant stuff. This
 # deletes the useless stuff and adds important context.
 
-discriminators = ["type", "kindString"]
+discriminators = ["kindString", "type"]
 classesByDiscriminator: dict[str, dict[str, type[BaseModel]]] = {
     disc: {} for disc in discriminators
 }
@@ -227,52 +235,54 @@ for cls in list(globals().values()):
             classesByDiscriminator[disc][arg] = cls
 
 
-def parse(json: dict[str, Any]) -> Root:
-    try:
-        return Root.parse_obj(json)
-    except ValidationError as exc:
-        from pprint import pprint
+def fix_exc_errors(json: Any, exc: ValidationError) -> None:
+    from pprint import pprint
 
-        s = sorted(
-            set(e["loc"][:-1] for e in exc.errors()), key=lambda loc: (-len(loc), loc)
-        )
-        handled = set()
-        errors = []
-        for loc in s:
-            if loc in handled:
+    s = sorted(
+        set(e["loc"][:-1] for e in exc.errors()), key=lambda loc: (-len(loc), loc)
+    )
+    handled = set()
+    errors = []
+    for loc in s:
+        if loc in handled:
+            continue
+        # Add all prefixes of the current loc to handled
+        for i in range(len(s)):
+            handled.add(loc[:i])
+
+        # follow path to get problematic subobject
+        o = json
+        for a in loc:
+            o = o[a]
+
+        # Work out the discriminator and use it to look up the appropriate class
+        for disc in discriminators:
+            if disc not in o:
                 continue
-            # Add all prefixes of the current loc to handled
-            for i in range(len(s)):
-                handled.add(loc[:i])
+            if o[disc] not in classesByDiscriminator[disc]:
+                continue
+            c = classesByDiscriminator[disc][o[disc]]
+            break
+        else:
+            print("Unable to locate discriminator for object:")
+            pprint(o, depth=1)
+            continue
 
-            # follow path to get problematic subobject
-            o = json
-            for a in loc:
-                o = o[a]  # type: ignore[index]
+        try:
+            c.parse_obj(o)
+        except ValidationError as e:
+            errs = e.errors()
 
-            # Work out the discriminator and use it to look up the appropriate class
-            for disc in discriminators:
-                if disc not in o:
-                    continue
-                if o[disc] not in classesByDiscriminator[disc]:
-                    continue
-                c = classesByDiscriminator[disc][o[disc]]
-                try:
-                    c.parse_obj(o)
-                except ValidationError as e:
-                    errs = e.errors()
+        for err in errs:
+            # Extend the loc so that it is relative to the top level object
+            err["loc"] = loc + err["loc"]
+            err["msg"] += "\n" + f"  Discriminator: {disc} = {o[disc]}\n"
+            print("\n")
+            print("loc:", err["loc"])
+            print("msg:", err["msg"])
+            print("obj:")
+            pprint(o, depth=1)
+            print("\n")
+        errors.extend(errs)
 
-                for err in errs:
-                    # Extend the loc so that it is relative to the top level object
-                    err["loc"] = loc + err["loc"]
-                    err["msg"] += "\n" + f"  Discriminator: {disc} = {o[disc]}\n"
-                    print("\n")
-                    print("loc:", err["loc"])
-                    print("msg:", err["msg"])
-                    print("obj:")
-                    pprint(o, depth=1)
-                    print("\n")
-                errors.extend(errs)
-
-        exc._error_cache = errors
-        raise
+    exc._error_cache = errors

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -429,7 +429,7 @@ def typedoc_output(
             else:
                 raise
         # typedoc emits a valid JSON file even if it finds no TS files in the dir:
-        return pyd.Root(**load(temp))
+        return pyd.parse(load(temp))
 
 
 from .pydantic_typedoc import IndexType

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import pytest
 
 from sphinx_js.ir import Attribute, Class, Function, Param, Pathname, Return
-from sphinx_js.pydantic_typedoc import Root
+from sphinx_js.pydantic_typedoc import parse
 from sphinx_js.typedoc import index_by_id, make_path_segments
 from tests.testing import NO_MATCH, TypeDocAnalyzerTestCase, TypeDocTestCase, dict_where
 
@@ -15,8 +15,8 @@ class IndexByIdTests(TestCase):
         """Make sure nodes get indexed."""
         # A simple TypeDoc JSON dump of a source file with a single, top-level
         # function with no params or return value:
-        json = Root(
-            **loads(
+        json = parse(
+            loads(
                 r"""{
           "id": 0,
           "name": "misterRoot",


### PR DESCRIPTION
Before:

```Text
E   pydantic.error_wrappers.ValidationError: 357 validation errors for Root
... Huge output!
```

After:

```Text
E   pydantic.error_wrappers.ValidationError: 2 validation errors for Root
E   children -> 0 -> children -> 13 -> type -> name
E     field required
E     Discriminator: type = intersection
E    (type=value_error.missing)
E   children -> 0 -> children -> 24 -> type -> name
E     field required
E     Discriminator: type = union
E    (type=value_error.missing)
```

See https://github.com/pydantic/pydantic/issues/5044