### PR TITLE
Add getSignature and setSignature to index

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -90,11 +90,14 @@ class Converter:
         if parent and isinstance(node, Signature):
             node.parent_member_properties = parent.member_properties()
 
-        # Burrow into everything that could contain more ID'd items. We don't
-        # need setSignature or getSignature for now. Do we need indexSignature?
+        # Burrow into everything that could contain more ID'd items
         children: list[Sequence[IndexType]] = []
 
         children.append(node.children)
+        if isinstance(node, Accessor):
+            children.append(node.getSignature)
+            children.append(node.setSignature)
+
         if isinstance(node, Callable):
             children.append(node.signatures)
 
@@ -522,7 +525,7 @@ class ExternalModule(NodeBase):
 
 class OtherNode(NodeBase):
     kindString: Literal[
-        "Enumeration", "Enumeration member", "Namespace", "Type alias", "Reference"
+        "Enumeration", "Enumeration Member", "Namespace", "Type alias", "Reference"
     ]
 
 

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -525,7 +525,7 @@ class ExternalModule(NodeBase):
 
 class OtherNode(NodeBase):
     kindString: Literal[
-        "Enumeration", "Enumeration Member", "Namespace", "Type alias", "Reference"
+        "Enumeration", "Enumeration member", "Namespace", "Type alias", "Reference"
     ]
 
 


### PR DESCRIPTION
We now set the path when indexing things so we should walk over everything that has a path.