### PR TITLE
Allow M in Enumeration Member to be upper or lower case

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -525,7 +525,12 @@ class ExternalModule(NodeBase):
 
 class OtherNode(NodeBase):
     kindString: Literal[
-        "Enumeration", "Enumeration member", "Namespace", "Type alias", "Reference"
+        "Enumeration",
+        "Enumeration Member",  # M changed to uppercase in version 0.22
+        "Enumeration member",
+        "Namespace",
+        "Type alias",
+        "Reference",
     ]
 
 


### PR DESCRIPTION
The case was changed in typedoc v0.22