### PR TITLE
Include typedoc_0.24.mjs in source distributions and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ include LICENSE
 include CODE_OF_CONDUCT.md
 include requirements_dev.txt
 include noxfile.py
+include sphinx_js/typedoc_0.24.mjs
 
 recursive-include tests *.py *.rst *.ts *.json *.js *.md


### PR DESCRIPTION
Without this change the package couldn't be pip-installed correctly. An attempt to use it would result in:

    # poetry run make html
    Running Sphinx v5.3.0
    WARNING: html_static_path entry '_static' does not exist
    /lune/ts-results-es/docs /lune/ts-results-es/docs/node_modules/typedoc/bin/typedoc
    /lune/ts-results-es /lune/ts-results-es/node_modules/typedoc/bin/typedoc
    node:internal/modules/cjs/loader:1042
      throw err;
      ^

    Error: Cannot find module '/root/.cache/pypoetry/virtualenvs/docs-kV_Wzi1i-py3.11/lib/python3.11/site-packages/sphinx_js/typedoc_0.24.mjs'
        at Module._resolveFilename (node:internal/modules/cjs/loader:1039:15)
        at Module._load (node:internal/modules/cjs/loader:885:27)
        at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
        at node:internal/main/run_main_module:23:47 {
      code: 'MODULE_NOT_FOUND',
      requireStack: []
    }

    Node.js v18.13.0

    Extension error (sphinx_js):
    Handler <function analyze at 0xffff9c288360> for event 'builder-inited' threw an exception (exception: Command '['node', '/root/.cache/pypoetry/virtualenvs/docs-kV_Wzi1i-py3.11/lib/python3.11/site-packages/sphinx_js/typedoc_0.24.mjs', '--entryPointStrategy', 'expand', '--tsconfig', '/lune/ts-results-es/docs/../tsconfig-esm.json', '--json', '/tmp/tmptyfv5uxe', '/lune/ts-results-es/src']' returned non-zero exit status 1.)
    make: *** [Makefile:20: html] Error 2