### PR TITLE
Drop support for typedoc 0.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11']
-        typedoc-version: ['0.23', '0.24', '0.25']
+        typedoc-version: ['0.24', '0.25']
         experimental: [false]
 
     name: Python ${{ matrix.python-version}} + typedoc ${{ matrix.typedoc-version }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def tests(session: Session) -> None:
 
 
 @nox.session(python=["3.11"])
-@nox.parametrize("typedoc", ["0.23", "0.24", "0.25"])
+@nox.parametrize("typedoc", ["0.24", "0.25"])
 def test_typedoc(session: Session, typedoc: str) -> None:
 
     session.install("-r", "requirements_dev.txt")

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -25,7 +25,7 @@ from .suffix_tree import SuffixTree
 
 __all__ = ["Analyzer"]
 
-MIN_TYPEDOC_VERSION = (0, 23, 0)
+MIN_TYPEDOC_VERSION = (0, 24, 0)
 
 
 @cache
@@ -491,10 +491,9 @@ class ClassOrInterface(NodeBase):
         for t in orig_types:
             if t.type != "reference":
                 continue
-            id = t.id or t.target
-            if not id:
+            if not t.target:
                 continue
-            rtype = converter.index[id]
+            rtype = converter.index[t.target]
             pathname = ir.Pathname(rtype.path)
             types.append(pathname)
             # else it's some other thing we should go implement
@@ -942,14 +941,9 @@ class IntrinsicType(TypeBase):
 class ReferenceType(TypeBase):
     type: Literal["reference"]
     name: str
-    id: int | None
     target: Any
 
     def _render_name_root(self, converter: Converter) -> str:
-        # test_generic_member() (currently skipped) tests this.
-        if self.id:
-            node = converter.index[self.id]
-            assert node.name
         return self.name
 
 


### PR DESCRIPTION
It doesn't allow that large of a cleanup and fixes no tests but the xrefs I am planning to add next break 0.23 support