### PR TITLE
Handle self referential function types without crashing

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -869,7 +869,11 @@ class Signature(TopLevelProperties):
         yield from riffle((inner(param) for param in self.parameters), ", ")
 
         yield "): "
-        ret = self.return_type(converter)[0].type
+        return_type = self.return_type(converter)
+        if return_type:
+            ret = return_type[0].type
+        else:
+            ret = "void"
         assert ret
         if isinstance(ret, str):
             yield ret
@@ -1062,6 +1066,14 @@ class OtherType(TypeBase):
         yield "<TODO: not implemented>"
 
 
+class UnknownType(TypeBase):
+    type: Literal["unknown"]
+    name: str
+
+    def _render_name_root(self, converter: Converter) -> Iterator[str | ir.TypeXRef]:
+        yield self.name
+
+
 AnyNode = Node | Project | Signature
 
 
@@ -1075,6 +1087,7 @@ Type = (
     | ReferenceType
     | ReflectionType
     | TupleType
+    | UnknownType
 )
 
 TypeD = Annotated[Type, Field(discriminator="type")]

--- a/tests/test_build_ts/source/class.ts
+++ b/tests/test_build_ts/source/class.ts
@@ -66,3 +66,9 @@ export function blah(a: OptionalThings) : ConstructorlessClass {
 export function thunk(b : typeof blah) {
 
 }
+
+/**
+ * A problematic self referential function
+ * @param b troublemaker
+ */
+export function quik(b: typeof quik)  {}


### PR DESCRIPTION
It still doesn't work well but at least it doesn't crash the whole program.