### PR TITLE
Better examples

### DIFF
--- a/sphinx_js/templates/common.rst
+++ b/sphinx_js/templates/common.rst
@@ -9,14 +9,14 @@
 
 {% macro examples(items) %}
 {% if items -%}
-**Examples:**
+.. admonition:: Example {%- if items|length > 1 -%} s {%- endif %}
 
-{% for example in items -%}
-.. code-block:: js
+   {% for example in items -%}
+   .. code-block:: js
 
-   {{ example|indent(3) }}
+      {{ example|indent(6) }}
 
-{% endfor %}
+   {% endfor %}
 {%- endif %}
 {% endmacro %}
 

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -59,7 +59,7 @@ class Tests(SphinxBuildTestCase):
             "autofunction_example",
             "exampleTag()\n\n"
             "   JSDoc example tag\n\n"
-            "   **Examples:**\n\n"
+            "   Example:\n\n"
             "      // This is the example.\n"
             "      exampleTag();\n",
         )
@@ -268,7 +268,7 @@ class Tests(SphinxBuildTestCase):
             "autoclass_example",
             "class ExampleClass()\n\n"
             "   JSDoc example tag for class\n\n"
-            "   **Examples:**\n\n"
+            "   Example:\n\n"
             "      // This is the example.\n"
             "      new ExampleClass();\n",
         )
@@ -306,7 +306,7 @@ class Tests(SphinxBuildTestCase):
             "autoattribute_example",
             "ExampleAttribute\n\n"
             "   JSDoc example tag for attribute\n\n"
-            "   **Examples:**\n\n"
+            "   Example:\n\n"
             "      // This is the example.\n"
             "      console.log(ExampleAttribute);\n",
         )

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -281,15 +281,15 @@ def test_func_render_callouts(function_render):
     )
     assert function_render(examples=["ex1", "ex2"]) == DEFAULT_RESULT + setindent(
         """
-        **Examples:**
+        .. admonition:: Examples
 
-        .. code-block:: js
+           .. code-block:: js
 
-           ex1
+              ex1
 
-        .. code-block:: js
+           .. code-block:: js
 
-           ex2
+              ex2
         """,
     )
     assert function_render(see_alsos=["see", "this too"]) == DEFAULT_RESULT + setindent(
@@ -299,4 +299,38 @@ def test_func_render_callouts(function_render):
            - :any:`see`
            - :any:`this too`
         """,
+    )
+
+
+def test_all(function_render):
+    assert function_render(
+        description="description",
+        params=[Param("a", "xx")],
+        deprecated=True,
+        exceptions=[Exc("TypeError", "")],
+        examples=["ex1"],
+        see_alsos=["see"],
+    ) == dedent(
+        """\
+        .. js:function:: blah(a)
+
+           .. note::
+
+              Deprecated.
+
+           description
+
+           :param a: xx
+           :throws TypeError:
+
+           .. admonition:: Example
+
+              .. code-block:: js
+
+                 ex1
+
+           .. seealso::
+
+              - :any:`see`
+       """
     )


### PR DESCRIPTION
Use `..admonition: example(s)` for example(s). This is one of two different ways autodoc can render
examples, it can also use `..rubric: example(s)`.