### PR TITLE
Add external xref formatting

### DIFF
--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -141,6 +141,7 @@ def setup(app: Sphinx) -> None:
         "js_source_path", default=["../"], rebuild="env", types=[str, list]
     )
     app.add_config_value("jsdoc_config_path", default=None, rebuild="env")
+    app.add_config_value("ts_xref_formatter", None, "env")
 
     # We could use a callable as the "default" param here, but then we would
     # have had to duplicate or build framework around the logic that promotes

--- a/sphinx_js/ir.py
+++ b/sphinx_js/ir.py
@@ -43,6 +43,7 @@ class TypeXRefInternal(TypeXRef):
 
 @define
 class TypeXRefExternal(TypeXRef):
+    package: str
     sourcefilename: str
     qualifiedName: str
 

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -985,6 +985,7 @@ class ReferenceType(TypeBase):
     type: Literal["reference"]
     name: str
     target: int | Target | None
+    package: str | None = None
     refersToTypeParameter: bool = False
 
     def _render_name_root(self, converter: Converter) -> Iterator[str | ir.TypeXRef]:
@@ -996,8 +997,12 @@ class ReferenceType(TypeBase):
             yield ir.TypeXRefInternal(self.name, node.path)
             return
         assert isinstance(self.target, Target)
+        assert self.package
         yield ir.TypeXRefExternal(
-            self.name, self.target.sourceFileName, self.target.qualifiedName
+            self.name,
+            self.package,
+            self.target.sourceFileName,
+            self.target.qualifiedName,
         )
 
 

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -587,7 +587,12 @@ class TypeNameTests(TypeDocAnalyzerTestCase):
         obj = self.analyzer.get_object(["partial"])
         t = deepcopy(obj.type)
         t[0].sourcefilename = "xxx"
-        assert t == [TypeXRefExternal("Partial", "xxx", "Partial"), "<", "string", ">"]
+        assert t == [
+            TypeXRefExternal("Partial", "typescript", "xxx", "Partial"),
+            "<",
+            "string",
+            ">",
+        ]
 
     def test_constrained_by_property(self):
 


### PR DESCRIPTION
This depends on the project specifically, so we added a config field called `ts_xref_formatter` which is a function that formats the external references.