### PR TITLE
Remove uses of unittest.TestCase

### DIFF
--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -6,7 +6,7 @@ from conftest import TYPEDOC_VERSION
 from tests.testing import SphinxBuildTestCase
 
 
-class TextBuilderTests(SphinxBuildTestCase):
+class TestTextBuilder(SphinxBuildTestCase):
     """Tests which require our big TS Sphinx tree to be built (as text)"""
 
     def test_autoclass_constructor(self):
@@ -152,7 +152,7 @@ class TextBuilderTests(SphinxBuildTestCase):
         )
 
 
-class HtmlBuilderTests(SphinxBuildTestCase):
+class TestHtmlBuilder(SphinxBuildTestCase):
     """Tests which require an HTML build of our Sphinx tree, for checking
     links"""
 

--- a/tests/test_jsdoc_analysis/test_jsdoc.py
+++ b/tests/test_jsdoc_analysis/test_jsdoc.py
@@ -30,7 +30,7 @@ def test_doclet_full_path():
     ]
 
 
-class FunctionTests(JsDocTestCase):
+class TestFunction(JsDocTestCase):
     file = "function.js"
 
     def test_top_level_and_function(self):
@@ -95,7 +95,7 @@ class FunctionTests(JsDocTestCase):
         )
 
 
-class ClassTests(JsDocTestCase):
+class TestClass(JsDocTestCase):
     file = "class.js"
 
     def test_class(self):

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -40,7 +40,7 @@ def join_descri(t: Type) -> str:
     return "".join(e.name if isinstance(e, TypeXRef) else e for e in t)
 
 
-class PopulateIndexTests(TestCase):
+class TestPopulateIndex(TestCase):
     def test_top_level_function(self):
         """Make sure nodes get indexed."""
         # A simple TypeDoc JSON dump of a source file with a single, top-level
@@ -129,7 +129,7 @@ class PopulateIndexTests(TestCase):
         assert root.name == "misterRoot"
 
 
-class PathSegmentsTests(TypeDocTestCase):
+class TestPathSegments(TypeDocTestCase):
     """Make sure ``make_path_segments() `` works on all its manifold cases."""
 
     files = ["pathSegments.ts"]
@@ -256,7 +256,7 @@ class PathSegmentsTests(TypeDocTestCase):
         ]
 
 
-class ConvertNodeTests(TypeDocAnalyzerTestCase):
+class TestConvertNode(TypeDocAnalyzerTestCase):
     """Test all the branches of ``convert_node()`` by analyzing every kind of
     TypeDoc JSON object."""
 
@@ -414,7 +414,7 @@ class ConvertNodeTests(TypeDocAnalyzerTestCase):
         assert setter.type == ["string"]
 
 
-class TypeNameTests(TypeDocAnalyzerTestCase):
+class TestTypeName(TypeDocAnalyzerTestCase):
     """Make sure our rendering of TypeScript types into text works."""
 
     files = ["types.ts"]

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -1,7 +1,6 @@
 import sys
 from os.path import dirname, join
 from shutil import rmtree
-from unittest import TestCase
 
 from pydantic import BaseModel
 from sphinx.cmd.build import main as sphinx_main
@@ -12,7 +11,7 @@ from sphinx_js.typedoc import Analyzer as TsAnalyzer
 from sphinx_js.typedoc import Converter, typedoc_output
 
 
-class ThisDirTestCase(TestCase):
+class ThisDirTestCase:
     """A TestCase that knows how to find the directory the subclass is defined
     in"""
 


### PR DESCRIPTION
They don't play well with pytest.mark.parametrize for instance.