### PR TITLE
Add hook to decide whether to destructure argument

### DIFF
--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -142,6 +142,7 @@ def setup(app: Sphinx) -> None:
     )
     app.add_config_value("jsdoc_config_path", default=None, rebuild="env")
     app.add_config_value("ts_xref_formatter", None, "env")
+    app.add_config_value("ts_should_destructure_arg", None, "env")
 
     # We could use a callable as the "default" param here, but then we would
     # have had to duplicate or build framework around the logic that promotes

--- a/tests/test_typedoc_analysis/source/types.ts
+++ b/tests/test_typedoc_analysis/source/types.ts
@@ -181,6 +181,15 @@ export function destructureTest2({
  */
 export function destructureTest3({ a, b }: { a: string; b: { c: string } }) {}
 
+
+/**
+ * A test for should_destructure_arg
+ */
+export function destructureTest4(destructureThisPlease: {
+  /**  The 'a' string. */
+  a: string;
+}) {}
+
 /**
  * An example with a function as argument
  *

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -611,6 +611,10 @@ class TestTypeName(TypeDocAnalyzerTestCase):
         obj = self.analyzer.get_object(["destructureTest3"])
         assert obj.params[0].name == "options"
         assert join_type(obj.params[0].type) == "{ a: string; b: { c: string; }; }"
+        obj = self.analyzer.get_object(["destructureTest4"])
+        assert obj.params[0].name == "destructureThisPlease.a"
+        assert join_type(obj.params[0].type) == "string"
+        assert obj.params[0].description == [DescriptionText(text="The 'a' string.")]
 
     def test_funcarg(self):
         obj = self.analyzer.get_object(["funcArg"])

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -94,7 +94,11 @@ class TypeDocAnalyzerTestCase(TypeDocTestCase):
     def setup_class(cls):
         """Run the TS analyzer over the TypeDoc output."""
         super().setup_class()
-        cls.analyzer = TsAnalyzer(cls.json, cls._source_dir)
+
+        def should_destructure(sig, p):
+            return p.name == "destructureThisPlease"
+
+        cls.analyzer = TsAnalyzer(cls.json, cls._source_dir, should_destructure)
 
 
 NO_MATCH = object()


### PR DESCRIPTION
This might seem a bit excessive but it's useful for Pyodide not to have to add @destructure tags for all options arguments.