### PR TITLE
Fix @deprecated with no body

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -437,7 +437,9 @@ class TopLevelProperties(Base):
 
     def _top_level_properties(self) -> TopLevelPropertiesDict:
         deprecated: Sequence[ir.DescriptionItem] | bool
-        deprecated = self.comment.get_tag_one("deprecated") or False
+        deprecated = self.comment.get_tag_one("deprecated")
+        if not deprecated:
+            deprecated = "deprecated" in self.comment.tags
         return dict(
             name=self.short_name(),
             path=ir.Pathname(self.path),

--- a/tests/test_build_ts/source/class.ts
+++ b/tests/test_build_ts/source/class.ts
@@ -77,7 +77,12 @@ export function selfReferential(b: typeof selfReferential)  {}
 /**
  * @deprecated since v20!
  */
-export function deprecatedFunction() {}
+export function deprecatedFunction1() {}
+
+/**
+ * @deprecated
+ */
+export function deprecatedFunction2() {}
 
 
 /**

--- a/tests/test_build_ts/source/docs/deprecated.rst
+++ b/tests/test_build_ts/source/docs/deprecated.rst
@@ -1,1 +1,3 @@
-.. js:autofunction:: deprecatedFunction
+.. js:autofunction:: deprecatedFunction1
+
+.. js:autofunction:: deprecatedFunction2

--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -111,11 +111,17 @@ class TestTextBuilder(SphinxBuildTestCase):
             "deprecated",
             dedent(
                 """\
-                deprecatedFunction()
+                deprecatedFunction1()
 
                    Note:
 
                      Deprecated: since v20!
+
+                deprecatedFunction2()
+
+                   Note:
+
+                     Deprecated.
                 """
             ),
         )


### PR DESCRIPTION
I screwed up the condition here before so a @deprecated tag with an empty body would not be noticed