### PR TITLE
Fix documentation for getters and setters

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -429,7 +429,11 @@ class TopLevelPropertiesDict(TypedDict):
 class TopLevelProperties(Base):
     name: str
     kindString: str
-    comment: Comment = Field(default_factory=Comment)
+    comment_: Comment = Field(default_factory=Comment, alias="comment")
+
+    @property
+    def comment(self) -> Comment:
+        return self.comment_
 
     def short_name(self) -> str:
         """Overridden by Modules and Namespaces to strip quotes."""
@@ -472,6 +476,14 @@ class Accessor(NodeBase):
     kindString: Literal["Accessor"]
     getSignature: "Signature | None" = None
     setSignature: "Signature | None" = None
+
+    @property
+    def comment(self) -> Comment:
+        if self.getSignature:
+            return self.getSignature.comment
+        if self.setSignature:
+            return self.setSignature.comment
+        return self.comment_
 
     def to_ir(self, converter: Converter) -> tuple[ir.Attribute, Sequence["Node"]]:
         if self.getSignature:
@@ -731,7 +743,11 @@ class TypeParameter(Base):
     kindString: Literal["Type parameter"]
     name: str
     type: "OptionalTypeD"
-    comment: Comment = Field(default_factory=Comment)
+    comment_: Comment = Field(default_factory=Comment, alias="comment")
+
+    @property
+    def comment(self) -> Comment:
+        return self.comment_
 
     def to_ir(self, converter: Converter) -> ir.TypeParam:
         extends = None
@@ -747,7 +763,12 @@ class TypeParameter(Base):
 
 class Param(Base):
     kindString: Literal["Parameter"] = "Parameter"
-    comment: Comment = Field(default_factory=Comment)
+    comment_: Comment = Field(default_factory=Comment, alias="comment")
+
+    @property
+    def comment(self) -> Comment:
+        return self.comment_
+
     defaultValue: str | None
     flags: Flags
     name: str

--- a/tests/test_build_ts/source/class.ts
+++ b/tests/test_build_ts/source/class.ts
@@ -122,3 +122,18 @@ export function weirdCodeInDescription() {
 export function spinxLinkInDescription() {
 
 }
+
+
+export class GetSetDocs {
+  /**
+   * Getter with comment
+   */
+  get a() {
+    return 7;
+  }
+
+  /**
+   * Setter with comment
+   */
+  set b(x) {}
+}

--- a/tests/test_build_ts/source/docs/getset.rst
+++ b/tests/test_build_ts/source/docs/getset.rst
@@ -1,0 +1,2 @@
+.. js:autoclass:: GetSetDocs
+   :members:

--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -190,6 +190,30 @@ class TestTextBuilder(SphinxBuildTestCase):
             ),
         )
 
+    def test_get_set(self):
+        self._file_contents_eq(
+            "getset",
+            dedent(
+                """\
+                class GetSetDocs()
+
+                   *exported from* "class"
+
+                   GetSetDocs.a
+
+                      **type:** number
+
+                      Getter with comment
+
+                   GetSetDocs.b
+
+                      **type:** any
+
+                      Setter with comment
+                """
+            ),
+        )
+
 
 class TestHtmlBuilder(SphinxBuildTestCase):
     """Tests which require an HTML build of our Sphinx tree, for checking

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -110,7 +110,7 @@ class TestPathSegments(TypeDocTestCase):
     def commented_object(self, comment, **kwargs):
         """Return the object from ``json`` having the given comment short-text."""
         comment = Comment(summary=[DescriptionItem(kind="text", text=comment)])
-        return dict_where(self.json, comment=comment, **kwargs)
+        return dict_where(self.json, comment_=comment, **kwargs)
 
     def commented_object_path(self, comment, **kwargs):
         """Return the path segments of the object with the given comment."""


### PR DESCRIPTION
When documenting a get/set pair, take the documentation comment from the getter. If for some weird reason there is only a setter, take it from the setter I guess?? This makes `comment` into a getter so that we can automatically pull a comment from the children of a class when appropriate.