### PR TITLE
Suppress inherited class members

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -607,7 +607,7 @@ class ClassOrInterface(NodeBase):
         constructor: ir.Function | None = None
         members = []
         for child in self.children:
-            if child.inheritedFrom is not None and child.comment == DEFAULT_COMMENT:
+            if child.inheritedFrom is not None:
                 continue
             if child.kindString == "Constructor":
                 # This really, really should happen exactly once per class.

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -479,6 +479,7 @@ class Accessor(NodeBase):
     kindString: Literal["Accessor"]
     getSignature: "Signature | None" = None
     setSignature: "Signature | None" = None
+    inheritedFrom: "ReferenceType | None" = None
 
     @property
     def comment(self) -> Comment:
@@ -527,6 +528,7 @@ class Callable(NodeBase):
         "Function",
     ]
     signatures: list["Signature"] = []
+    inheritedFrom: "ReferenceType | None" = None
 
     @property
     def comment(self) -> Comment:
@@ -605,6 +607,8 @@ class ClassOrInterface(NodeBase):
         constructor: ir.Function | None = None
         members = []
         for child in self.children:
+            if child.inheritedFrom is not None and child.comment == DEFAULT_COMMENT:
+                continue
             if child.kindString == "Constructor":
                 # This really, really should happen exactly once per class.
                 # Type parameter cannot appear on constructor declaration so copy
@@ -659,6 +663,7 @@ class Member(NodeBase):
         "Variable",
     ]
     type: "TypeD"
+    inheritedFrom: "ReferenceType | None" = None
 
     def to_ir(
         self, converter: Converter
@@ -829,7 +834,7 @@ class Signature(TopLevelProperties):
     parameters: list["Param"] = []
     sources: list[Source] = []
     type: "TypeD"  # This is the return type!
-    inheritedFrom: Any = None
+    inheritedFrom: "ReferenceType | None" = None
     parent_member_properties: MemberProperties = {}  # type: ignore[typeddict-item]
 
     def _path_segments(self, base_dir: str) -> list[str]:
@@ -944,10 +949,6 @@ class Signature(TopLevelProperties):
     def to_ir(
         self, converter: Converter
     ) -> tuple[ir.Function | None, Sequence["Node"]]:
-        if self.inheritedFrom is not None:
-            if self.comment == Comment():
-                return None, []
-
         if self.name.startswith("["):
             # a symbol.
             # \u2024 looks like a period but is not a period.

--- a/tests/test_build_ts/source/class.ts
+++ b/tests/test_build_ts/source/class.ts
@@ -137,3 +137,15 @@ export class GetSetDocs {
    */
   set b(x) {}
 }
+
+export class Base {
+  /** Some docs for f */
+  f() {}
+
+  get a() { return 7; }
+}
+
+export class Extension extends Base {
+  /** Some docs for g */
+  g() {}
+}

--- a/tests/test_build_ts/source/docs/inherited_docs.rst
+++ b/tests/test_build_ts/source/docs/inherited_docs.rst
@@ -1,0 +1,5 @@
+.. js:autoclass:: Base
+   :members:
+
+.. js:autoclass:: Extension
+   :members:

--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -214,6 +214,34 @@ class TestTextBuilder(SphinxBuildTestCase):
             ),
         )
 
+    def test_inherited_docs(self):
+        # Check that we aren't including documentation entries from the base class
+        self._file_contents_eq(
+            "inherited_docs",
+            dedent(
+                """\
+                class Base()
+
+                   *exported from* "class"
+
+                   Base.a
+
+                      **type:** number
+
+                   Base.f()
+
+                      Some docs for f
+
+                class Extension()
+
+                   *exported from* "class"
+
+                   **Extends:**
+                      * "Base()"
+                """
+            ),
+        )
+
 
 class TestHtmlBuilder(SphinxBuildTestCase):
     """Tests which require an HTML build of our Sphinx tree, for checking

--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -238,6 +238,10 @@ class TestTextBuilder(SphinxBuildTestCase):
 
                    **Extends:**
                       * "Base()"
+
+                   Extension.g()
+
+                      Some docs for g
                 """
             ),
         )


### PR DESCRIPTION
Don't need to duplicate these between the base class and the subclass.