### PR TITLE
Make ts_xref_formatter apply to all kinds of xref

### DIFF
--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -313,12 +313,7 @@ class JsRenderer:
         return "".join(res)
 
     def render_xref(self, s: TypeXRef, escape: bool = False) -> str:
-        if isinstance(s, TypeXRefInternal):
-            name = rst.escape(s.name)
-            result = f":js:class:`{name}`"
-        else:
-            assert isinstance(s, TypeXRefExternal)
-            result = self._xref_formatter(s)
+        result = self._xref_formatter(s)
         if escape:
             result = rst.escape(result)
         return result

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -31,8 +31,6 @@ from .ir import (
     Type,
     TypeParam,
     TypeXRef,
-    TypeXRefExternal,
-    TypeXRefInternal,
 )
 from .jsdoc import Analyzer as JsAnalyzer
 from .parsers import PathVisitor
@@ -57,7 +55,7 @@ class JsRenderer:
 
     _renderer_type: Literal["function", "class", "attribute"]
     _template: str
-    _xref_formatter: Callable[[TypeXRefExternal], str]
+    _xref_formatter: Callable[[TypeXRef], str]
     _partial_path: list[str]
     _explicit_formal_params: str
     _content: list[str]
@@ -67,13 +65,13 @@ class JsRenderer:
         raise NotImplementedError
 
     def _set_xref_formatter(
-        self, formatter: Callable[[Config, TypeXRefExternal], str] | None
+        self, formatter: Callable[[Config, TypeXRef], str] | None
     ) -> None:
         if formatter:
             self._xref_formatter = partial(formatter, self._app.config)
             return
 
-        def default_xref_formatter(xref: TypeXRefExternal) -> str:
+        def default_xref_formatter(xref: TypeXRef) -> str:
             return xref.name
 
         self._xref_formatter = default_xref_formatter

--- a/tests/test_build_ts/source/docs/conf.py
+++ b/tests/test_build_ts/source/docs/conf.py
@@ -9,6 +9,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 jsdoc_config_path = "../tsconfig.json"
 js_language = "typescript"
 from sphinx.util import rst
+
 from sphinx_js.ir import TypeXRefInternal
 
 

--- a/tests/test_build_ts/source/docs/conf.py
+++ b/tests/test_build_ts/source/docs/conf.py
@@ -8,3 +8,13 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 jsdoc_config_path = "../tsconfig.json"
 js_language = "typescript"
+from sphinx.util import rst
+from sphinx_js.ir import TypeXRefInternal
+
+
+def ts_xref_formatter(config, xref):
+    if isinstance(xref, TypeXRefInternal):
+        name = rst.escape(xref.name)
+        return f":js:class:`{name}`"
+    else:
+        return xref.name

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,8 +1,8 @@
 from textwrap import dedent, indent
 
 import pytest
-
 from sphinx.util import rst
+
 from sphinx_js.ir import (
     DescriptionCode,
     DescriptionText,
@@ -51,12 +51,14 @@ def test_render_description():
         And some closing words."""
     )
 
+
 def ts_xref_formatter(config, xref):
     if isinstance(xref, TypeXRefInternal):
         name = rst.escape(xref.name)
         return f":js:class:`{name}`"
     else:
         return xref.name
+
 
 @pytest.fixture()
 def function_renderer():

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -2,6 +2,7 @@ from textwrap import dedent, indent
 
 import pytest
 
+from sphinx.util import rst
 from sphinx_js.ir import (
     DescriptionCode,
     DescriptionText,
@@ -50,6 +51,12 @@ def test_render_description():
         And some closing words."""
     )
 
+def ts_xref_formatter(config, xref):
+    if isinstance(xref, TypeXRefInternal):
+        name = rst.escape(xref.name)
+        return f":js:class:`{name}`"
+    else:
+        return xref.name
 
 @pytest.fixture()
 def function_renderer():
@@ -63,7 +70,7 @@ def function_renderer():
     renderer._app = _app
     renderer._explicit_formal_params = None
     renderer._content = []
-    renderer._set_xref_formatter(None)
+    renderer._set_xref_formatter(ts_xref_formatter)
     return renderer
 
 


### PR DESCRIPTION
Before it specifically applied to external xrefs but I think it's more convenient for it to apply to all xrefs.