### PR TITLE
Add slash space between type xrefs and surrounding text

### DIFF
--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -303,12 +303,14 @@ class JsRenderer:
             s = "".join(strs())
             if escape:
                 s = rst.escape(s)
-            res.append(s)
+            if s:
+                res.append(s)
             if not xref:
                 break
             res.append(self.render_xref(xref[0], escape))
 
-        return "".join(res)
+        print(res)
+        return r"\ ".join(res)
 
     def render_xref(self, s: TypeXRef, escape: bool = False) -> str:
         result = self._xref_formatter(s)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -232,6 +232,12 @@ def test_render_xref(function_renderer: AutoFunctionRenderer):
         function_renderer.render_type([TypeXRefInternal(name="A", path=["a.", "A"])])
         == ":js:class:`A`"
     )
+    assert (
+        function_renderer.render_type(
+            [TypeXRefInternal(name="A", path=["a.", "A"]), "[]"]
+        )
+        == r":js:class:`A`\ []"
+    )
     xref_external = TypeXRefExternal("A", "blah", "a.ts", "a.A")
     assert function_renderer.render_type([xref_external]) == "A"
     res = []


### PR DESCRIPTION
These escapes make sure that any rst in the xrefs renders as expected