### PR TITLE
Add option to make types bold

### DIFF
--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -142,6 +142,7 @@ def setup(app: Sphinx) -> None:
     )
     app.add_config_value("jsdoc_config_path", default=None, rebuild="env")
     app.add_config_value("ts_type_xref_formatter", None, "env")
+    app.add_config_value("ts_type_bold", False, "env")
     app.add_config_value("ts_should_destructure_arg", None, "env")
     app.add_config_value("ts_post_convert", None, "env")
 

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -75,7 +75,6 @@ class JsRenderer:
         def default_type_xref_formatter(xref: TypeXRef) -> str:
             return xref.name
 
-
     def _set_type_text_formatter(
         self, formatter: Callable[[Config, str], str] | None
     ) -> None:
@@ -103,7 +102,8 @@ class JsRenderer:
         self._directive = directive
         self._app = app
         self._set_type_xref_formatter(app.config.ts_type_xref_formatter)
-        def bold_formatter(conf, text):
+
+        def bold_formatter(conf: Config, text: str) -> str:
             parts = ["**" + part + "**" for part in text.split(" ") if part]
             return " ".join(parts).strip()
 
@@ -111,7 +111,6 @@ class JsRenderer:
             self._set_type_text_formatter(bold_formatter)
         else:
             self._set_type_text_formatter(None)
-        
 
         # content, arguments, options, app: all need to be accessible to
         # template_vars, so we bring them in on construction and stow them away

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -56,6 +56,7 @@ class JsRenderer:
     _renderer_type: Literal["function", "class", "attribute"]
     _template: str
     _type_xref_formatter: Callable[[TypeXRef], str]
+    _type_text_formatter: Callable[[str], str]
     _partial_path: list[str]
     _explicit_formal_params: str
     _content: list[str]
@@ -74,7 +75,18 @@ class JsRenderer:
         def default_type_xref_formatter(xref: TypeXRef) -> str:
             return xref.name
 
-        self._type_xref_formatter = default_type_xref_formatter
+
+    def _set_type_text_formatter(
+        self, formatter: Callable[[Config, str], str] | None
+    ) -> None:
+        if formatter:
+            self._type_text_formatter = partial(formatter, self._app.config)
+            return
+
+        def default_type_text_formatter(text: str) -> str:
+            return text
+
+        self._type_text_formatter = default_type_text_formatter
 
     def __init__(
         self,
@@ -91,6 +103,11 @@ class JsRenderer:
         self._directive = directive
         self._app = app
         self._set_type_xref_formatter(app.config.ts_type_xref_formatter)
+        if app.config.ts_type_bold:
+            self._set_type_text_formatter(lambda conf, text: "**" + text + "**")
+        else:
+            self._set_type_text_formatter(None)
+        
 
         # content, arguments, options, app: all need to be accessible to
         # template_vars, so we bring them in on construction and stow them away
@@ -301,6 +318,8 @@ class JsRenderer:
         while True:
             xref: list[TypeXRef] = []
             s = "".join(strs())
+            if s:
+                s = self._type_text_formatter(s)
             if escape:
                 s = rst.escape(s)
             if s:

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -103,8 +103,12 @@ class JsRenderer:
         self._directive = directive
         self._app = app
         self._set_type_xref_formatter(app.config.ts_type_xref_formatter)
+        def bold_formatter(conf, text):
+            parts = ["**" + part + "**" for part in text.split(" ") if part]
+            return " ".join(parts).strip()
+
         if app.config.ts_type_bold:
-            self._set_type_text_formatter(lambda conf, text: "**" + text + "**")
+            self._set_type_text_formatter(bold_formatter)
         else:
             self._set_type_text_formatter(None)
         

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -73,6 +73,7 @@ def function_renderer():
     renderer._explicit_formal_params = None
     renderer._content = []
     renderer._set_type_xref_formatter(ts_xref_formatter)
+    renderer._set_type_text_formatter(None)
     return renderer
 
 

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -521,6 +521,7 @@ class TestTypeName(TypeDocAnalyzerTestCase):
 
         # TODO: this part maybe belongs in a unit test for the renderer or something
         a = AutoFunctionRenderer.__new__(AutoFunctionRenderer)
+        a._set_type_text_formatter(None)
         a._explicit_formal_params = None
         a._content = []
         rst = a.rst([obj.name], obj)
@@ -540,6 +541,7 @@ class TestTypeName(TypeDocAnalyzerTestCase):
             description=[DescriptionText("The type we contain")],
         )
         a = AutoClassRenderer.__new__(AutoClassRenderer)
+        a._set_type_text_formatter(None)
         a._explicit_formal_params = None
         a._content = []
         a._options = {}


### PR DESCRIPTION
This makes xrefs look a bit better because sphinx seems to automatically render them in bold