### PR TITLE
Add TypeXRefIntrinsic wrapper for intrinsic types

### DIFF
--- a/sphinx_js/ir.py
+++ b/sphinx_js/ir.py
@@ -37,6 +37,11 @@ class TypeXRef:
 
 
 @define
+class TypeXRefIntrinsic(TypeXRef):
+    pass
+
+
+@define
 class TypeXRefInternal(TypeXRef):
     path: list[str]
 

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -1059,7 +1059,7 @@ class IntrinsicType(TypeBase):
     name: str
 
     def _render_name_root(self, converter: Converter) -> Iterator[str | ir.TypeXRef]:
-        yield self.name
+        yield ir.TypeXRefIntrinsic(self.name)
 
 
 class ReferenceType(TypeBase):


### PR DESCRIPTION
Probably people won't want to xref intrinsic types but maybe other sorts of transforms to all type names would be desired. Anyways this is more consistent