### PR TITLE
When destructuring arguments, sort by source location

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -913,7 +913,11 @@ class Signature(TopLevelProperties):
         assert isinstance(type, ReflectionType)
         decl = type.declaration
         result = []
-        for child in decl.children:
+        def key(c):
+            src = c.sources[0]
+            return (src.line, src.character)
+        children = sorted(decl.children, key=key)
+        for child in children:
             assert isinstance(child, Member)
             result.append(
                 Param(

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -913,9 +913,11 @@ class Signature(TopLevelProperties):
         assert isinstance(type, ReflectionType)
         decl = type.declaration
         result = []
-        def key(c):
+
+        def key(c: Node) -> tuple[int, int]:
             src = c.sources[0]
             return (src.line, src.character)
+
         children = sorted(decl.children, key=key)
         for child in children:
             assert isinstance(child, Member)


### PR DESCRIPTION
This puts keyword arguments in the order they occur in the source