### PR TITLE
Call `post_convert` immediately following `to_ir`

### DIFF
--- a/sphinx_js/analyzer_utils.py
+++ b/sphinx_js/analyzer_utils.py
@@ -28,8 +28,6 @@ def search_node_modules(cmdname: str, cmdpath: str, dir: str | Path) -> str:
     # search for local install
     for base in parent_dirs:
         typedoc = base / "node_modules" / cmdpath
-        print(base, typedoc)
-
         if typedoc.is_file():
             return str(typedoc.resolve())
 


### PR DESCRIPTION
This uses a decorator to call post_convert after each call to `to_ir` so that it can't be forgotten. In order to allow subclasses to restrict the type of `to_ir`, we use a decorator (I originally tried a similar approach as with `type.render_name` but it doesn't work with the subclass type restrictions). Typing the decorator took a bit of trial and error, but the key thing is to say that the decorator doesn't change the type of the function.