### PR TITLE
Add serialization for ir

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,7 @@ repos:
         args: []
         additional_dependencies:
           - attrs
+          - cattrs
           - jinja2
           - nox
           - pydantic

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         # https://github.com/pallets/jinja/issues/1585
         "markupsafe==2.0.1",
         "attrs",
+        "cattrs",
     ],
     python_requires=">=3.10",
     classifiers=[

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -366,10 +366,10 @@ class JsRenderer(Renderer):
         result = "\n".join(lines) + "\n"
         return result
 
-    def _formal_params(self, obj: Function | Class) -> str:
-        """Return the JS function or class params, looking first to any
-        explicit params written into the directive and falling back to those in
-        comments or JS code.
+    def _formal_params(self, obj: Function) -> str:
+        """Return the JS function params, looking first to any explicit params
+        written into the directive and falling back to those in comments or JS
+        code.
 
         Return a ReST-escaped string ready for substitution into the template.
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,6 +1,23 @@
+from inspect import getmembers
+from json import dumps, loads
+
 import pytest
 
-from sphinx_js.ir import Param
+from sphinx_js.ir import (
+    Attribute,
+    DescriptionCode,
+    DescriptionName,
+    DescriptionText,
+    Function,
+    Param,
+    Pathname,
+    Return,
+    TopLevel,
+    TypeXRefExternal,
+    TypeXRefInternal,
+    converter,
+    json_to_ir,
+)
 
 
 def test_default():
@@ -15,3 +32,104 @@ def test_missing_default():
     value should raise an error."""
     with pytest.raises(ValueError):
         Param(name="fred", has_default=True)
+
+
+top_level_base = TopLevel(
+    name="blah",
+    block_tags={},
+    deppath="x",
+    deprecated=False,
+    description=[],
+    examples=[],
+    exported_from=Pathname([]),
+    filename="",
+    line=7,
+    modifier_tags=[],
+    path=Pathname([]),
+    properties=[],
+    see_alsos=[],
+    kind="",
+)
+tl_dict = {k: v for k, v in getmembers(top_level_base) if not k.startswith("_")}
+del tl_dict["kind"]
+
+attribute_base = Attribute(
+    **tl_dict,
+    is_abstract=False,
+    is_optional=False,
+    is_static=False,
+    is_private=False,
+    type=[]
+)
+attr_dict = {k: v for k, v in getmembers(attribute_base) if not k.startswith("_")}
+
+
+def attr_with(**kwargs):
+    return Attribute(**(attr_dict | kwargs))
+
+
+function_base = Function(
+    **tl_dict,
+    is_abstract=False,
+    is_optional=False,
+    is_static=False,
+    is_private=False,
+    is_async=False,
+    params=[],
+    exceptions=[],
+    returns=[]
+)
+func_dict = {k: v for k, v in getmembers(function_base) if not k.startswith("_")}
+
+
+def func_with(**kwargs):
+    return Function(**(func_dict | kwargs))
+
+
+# Check that we can successfully serialize and desrialize IR.
+
+
+@pytest.mark.parametrize(
+    "x",
+    [
+        attr_with(),
+        attr_with(type="a string"),
+        attr_with(
+            type=[
+                TypeXRefInternal("xx", ["a", "b"]),
+                "x",
+                TypeXRefExternal("blah", "pkg", "sfn", "qn"),
+            ]
+        ),
+        attr_with(
+            deprecated=True,
+        ),
+        attr_with(
+            deprecated="a string",
+        ),
+        attr_with(
+            deprecated=[
+                DescriptionName("name"),
+                DescriptionText("xx"),
+                DescriptionCode("yy"),
+            ],
+        ),
+        func_with(),
+        func_with(params=[Param(name="fred", has_default=True, default="boof")]),
+        func_with(
+            params=[Param(name="fred", has_default=False)],
+            returns=[
+                Return(
+                    type=[TypeXRefInternal("a", [])], description=[DescriptionText("x")]
+                )
+            ],
+        ),
+    ],
+)
+def test_ir_serialization(x):
+    l = [x]
+    s = converter.unstructure(l)
+    s2 = loads(dumps(s))
+    assert s == s2
+    l2 = json_to_ir(s2)
+    assert l2 == l


### PR DESCRIPTION
I used cattrs for ir serialziation instead of pydantic because cattrs allows us to add serialization to an existing attrs class without changing its API. If we changed the classes in `ir.py` into Pydantic classes all of the spots where we instantiate them in Python would have to change. Using Pydantic would involve less added code but more changes to existing code.