### PR TITLE
Don't fail when something is reexported

### DIFF
--- a/sphinx_js/js/convertTopLevel.ts
+++ b/sphinx_js/js/convertTopLevel.ts
@@ -392,13 +392,19 @@ export class Converter {
    * Reflections that still need converting.
    */
   toIr(object: DeclarationReflection | SignatureReflection): ConvertResult {
+    // ReflectionKinds that we give no conversion.
     if (
       [
         ReflectionKind.Module,
         ReflectionKind.Namespace,
+        // TODO: document TypeAliases
         ReflectionKind.TypeAlias,
+        // TODO: document enums
         ReflectionKind.Enum,
         ReflectionKind.EnumMember,
+        // A ReferenceReflection is when we reexport something.
+        // TODO: should we handle this somehow?
+        ReflectionKind.Reference,
       ].includes(object.kind)
     ) {
       // TODO: The children of these have no rendered parent in the docs. If

--- a/tests/test_typedoc_analysis/source/exports.ts
+++ b/tests/test_typedoc_analysis/source/exports.ts
@@ -1,0 +1,4 @@
+export interface Blah {
+  a: number;
+  b: string;
+}

--- a/tests/test_typedoc_analysis/source/nodes.ts
+++ b/tests/test_typedoc_analysis/source/nodes.ts
@@ -47,3 +47,6 @@ export class ClassWithProperties {
 export class Indexable {
   [id: string]: any; // smoketest
 }
+
+// Test that we don't fail on a reexport
+export { Blah } from "./exports";

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -171,7 +171,7 @@ class TestConvertNode(TypeDocAnalyzerTestCase):
     """Test all the branches of ``convert_node()`` by analyzing every kind of
     TypeDoc JSON object."""
 
-    files = ["nodes.ts"]
+    files = ["nodes.ts", "exports.ts"]
 
     def test_class1(self):
         """Test that superclasses, implemented interfaces, abstractness, and


### PR DESCRIPTION
Reexporting an object creates a Reference Reflection. Perhaps eventually we'll want to note that the object is reexported, or choose to document it where it is reexported rather than where it is defined, or something. This just prevents a crash.