### PR TITLE
Fix name of signatures that we converted from properties

### DIFF
--- a/sphinx_js/js/convertTopLevel.ts
+++ b/sphinx_js/js/convertTopLevel.ts
@@ -777,6 +777,10 @@ export class Converter {
     // raise an exception while being built. An eventual solution might be to
     // store the signatures in a one-to- many attr of Functions.
     const first_sig = func.signatures![0]; // Should always have at least one
+
+    // Make sure name matches, can be different in case this comes from
+    // isAnonymousTypeLiteral returning true.
+    first_sig.name = func.name;
     const params = this._destructureParams(first_sig);
     let returns: Return[] = [];
     let is_async = false;

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -440,6 +440,7 @@ class TestTypeName(TypeDocAnalyzerTestCase):
         """Make sure members of a class have their type params taken into
         account."""
         obj = self.analyzer.get_object(["add"])
+        assert obj.name == "add"
         assert len(obj.params) == 2
         T = ["T"]
         assert obj.params[0].type == T


### PR DESCRIPTION
We take the inner reflection type and use it as our property reflection. The reflection type has name __type and so do its signatures. We renamed the reflection type to the name of the property but missed the signatures. This meant that these properties got rendered as __type