### PR TITLE
Fix ir.ts handling of missing attributes

### DIFF
--- a/sphinx_js/ir.py
+++ b/sphinx_js/ir.py
@@ -52,8 +52,8 @@ class TypeXRefExternal:
     name: str
     package: str
     # TODO: use snake case for these like for everything else
-    sourcefilename: str
-    qualifiedName: str
+    sourcefilename: str | None
+    qualifiedName: str | None
     type: Literal["external"] = "external"
 
 

--- a/sphinx_js/js/ir.ts
+++ b/sphinx_js/js/ir.ts
@@ -22,8 +22,8 @@ export type TypeXRefInternal = {
 export type TypeXRefExternal = {
   name: string;
   package: string;
-  sourcefilename: string | undefined;
-  qualifiedName: string | undefined;
+  sourcefilename: string | null;
+  qualifiedName: string | null;
   type: "external";
 };
 
@@ -75,7 +75,7 @@ export type Param = {
   is_variadic: boolean;
   has_default: boolean;
   default: string | NoDefault;
-  type?: Type;
+  type: Type;
 };
 
 export type Return = {
@@ -85,7 +85,7 @@ export type Return = {
 
 export type Module = {
   filename: string;
-  deppath?: string;
+  deppath: string;
   path: Pathname;
   line: number;
   attributes: TopLevel[];
@@ -97,7 +97,7 @@ export type TopLevel = {
   name: string;
   path: Pathname;
   filename: string;
-  deppath?: string;
+  deppath: string;
   description: Description;
   modifier_tags: string[];
   block_tags: { [key: string]: Description[] };
@@ -106,7 +106,7 @@ export type TopLevel = {
   examples: Description[];
   see_alsos: string[];
   properties: Attribute[];
-  exported_from?: Pathname;
+  exported_from: Pathname | null;
   documentation_root: boolean;
 };
 

--- a/sphinx_js/js/renderType.ts
+++ b/sphinx_js/js/renderType.ts
@@ -167,8 +167,8 @@ class TypeRenderer implements TypeVisitor<Type> {
       const res: TypeXRefExternal = {
         name: type.name,
         package: type.package,
-        qualifiedName: fileInfo?.qualifiedName,
-        sourcefilename: fileInfo?.sourceFileName,
+        qualifiedName: fileInfo?.qualifiedName || null,
+        sourcefilename: fileInfo?.sourceFileName || null,
         type: "external",
       };
       return this.addTypeParams(type, [res]);


### PR DESCRIPTION
We can't use a ? unless we fix things on the Python side because `undefined` turns into an entirely missing entry. If we want to turn it into `None` we need to either put a `null` in javascript or set `None` as the default value in `ir.py`. I removed a lot of the `?`'s because we don't use them, but qualifiedName and sourcefilename do sometimes seem to go missing right now. Maybe we can fix that later.