### PR TITLE
Add a typedoc plugin to resolve References to private type aliases

### DIFF
--- a/sphinx_js/js/convertTopLevel.ts
+++ b/sphinx_js/js/convertTopLevel.ts
@@ -31,6 +31,7 @@ import {
 } from "./ir.ts";
 import { sep, relative } from "path";
 import { SphinxJsConfig } from "./sphinxJsConfig.ts";
+import { ReadonlySymbolToType } from "./redirectPrivateAliases.ts";
 
 export function parseFilePath(path: string, base_dir: string): string[] {
   // First we want to know if path is under base_dir.
@@ -329,6 +330,7 @@ export class Converter {
   readonly project: ProjectReflection;
   readonly basePath: string;
   readonly config: SphinxJsConfig;
+  readonly symbolToType: ReadonlySymbolToType;
 
   readonly pathMap: Map<DeclarationReflection | SignatureReflection, Pathname>;
   readonly filePathMap: Map<
@@ -341,17 +343,25 @@ export class Converter {
     project: ProjectReflection,
     basePath: string,
     config: SphinxJsConfig,
+    symbolToType: ReadonlySymbolToType,
   ) {
     this.project = project;
     this.basePath = basePath;
     this.config = config;
+    this.symbolToType = symbolToType;
     this.pathMap = new Map();
     this.filePathMap = new Map();
     this.documentationRoots = new Set();
   }
 
   renderType(type: SomeType, context: TypeContext = TypeContext.none): Type {
-    return renderType(this.basePath, this.pathMap, type, context);
+    return renderType(
+      this.basePath,
+      this.pathMap,
+      this.symbolToType,
+      type,
+      context,
+    );
   }
 
   computePaths() {

--- a/sphinx_js/js/redirectPrivateAliases.ts
+++ b/sphinx_js/js/redirectPrivateAliases.ts
@@ -1,0 +1,151 @@
+/**
+ * This is very heavily inspired by typedoc-plugin-missing-exports.
+ *
+ * The goal isn't to document the missing exports, but rather to remove them
+ * from the documentation of actually exported stuff. If someone says:
+ *
+ * ```
+ * type MyPrivateAlias = ...
+ *
+ * function f(a: MyPrivateAlias) {
+ *
+ * }
+ * ```
+ *
+ * Then the documentation for f should document the value of MyPrivateAlias. We
+ * create a ReflectionType for each missing export and stick them in a
+ * SymbolToType map which we add to the application. In renderType.ts, if we
+ * have a reference type we check if it's in the SymbolToType map and if so we
+ * can use the reflection in place of the reference.
+ *
+ * More or less unrelatedly, we also add the --sphinxJsConfig option to the
+ * options parser so we can pass the sphinxJsConfig on the command line.
+ */
+import {
+  Application,
+  Context,
+  Converter,
+  DeclarationReflection,
+  ProjectReflection,
+  ReferenceType,
+  Reflection,
+  ReflectionKind,
+  SomeType,
+} from "typedoc";
+import ts from "typescript";
+
+// Map from the Symbol that is the target of the broken reference to the type
+// reflection that it should be replaced by. Depending on whether the reference
+// type holds a symbolId or a reflection, we use fileName:position or
+// fileName:symbolName as the key (respectively). We could always use the
+// symbolName but the position is more specific.
+type SymbolToTypeKey = `${string}:${number}` | `${string}:${string}`;
+export type SymbolToType = Map<SymbolToTypeKey, SomeType>;
+export type ReadonlySymbolToType = ReadonlyMap<SymbolToTypeKey, SomeType>;
+
+const ModuleLike: ReflectionKind =
+  ReflectionKind.Project | ReflectionKind.Module;
+
+function getOwningModule(context: Context): Reflection {
+  let refl = context.scope;
+  // Go up the reflection hierarchy until we get to a module
+  while (!refl.kindOf(ModuleLike)) {
+    refl = refl.parent!;
+  }
+  return refl;
+}
+
+/**
+ * @param app The typedoc app
+ * @returns The type reference redirect table to be used in renderType.ts
+ */
+export function redirectPrivateTypes(app: Application): ReadonlySymbolToType {
+  const referencedSymbols = new Map<Reflection, Set<ts.Symbol>>();
+  const knownPrograms = new Map<Reflection, ts.Program>();
+  const symbolToType: SymbolToType = new Map<`${string}:${number}`, SomeType>();
+
+  app.converter.on(
+    Converter.EVENT_CREATE_DECLARATION,
+    (context: Context, refl: Reflection) => {
+      if (refl.kindOf(ModuleLike)) {
+        knownPrograms.set(refl, context.program);
+      }
+    },
+  );
+
+  /**
+   * Get the set of ts.symbols referenced from a ModuleReflection or
+   * ProjectReflection if there is only one file.
+   */
+  function getReferencedSymbols(owningModule: Reflection): Set<ts.Symbol> {
+    let set = referencedSymbols.get(owningModule);
+    if (set) {
+      return set;
+    }
+    set = new Set();
+    referencedSymbols.set(owningModule, set);
+    return set;
+  }
+
+  function discoverMissingExports(
+    owningModule: Reflection,
+    context: Context,
+  ): ts.Symbol[] {
+    // An export is missing if it was referenced and is not contained in the
+    // documented
+    const referenced = getReferencedSymbols(owningModule);
+    return Array.from(referenced).filter((s) => {
+      const refl = context.project.getReflectionFromSymbol(s);
+      return !refl || refl.flags.isPrivate;
+    });
+  }
+
+  const origCreateSymbolReference = ReferenceType.createSymbolReference;
+  ReferenceType.createSymbolReference = function (symbol, context, name) {
+    const owningModule = getOwningModule(context);
+    getReferencedSymbols(owningModule).add(symbol);
+    return origCreateSymbolReference.call(this, symbol, context, name);
+  };
+
+  function onResolveBegin(context: Context) {
+    const modules: (DeclarationReflection | ProjectReflection)[] =
+      context.project.getChildrenByKind(ReflectionKind.Module);
+    if (modules.length === 0) {
+      // Single entry point, just target the project.
+      modules.push(context.project);
+    }
+
+    for (const mod of modules) {
+      const program = knownPrograms.get(mod);
+      if (!program) continue;
+
+      // Nasty hack here that will almost certainly break in future TypeDoc versions.
+      context.setActiveProgram(program);
+
+      const missing = discoverMissingExports(mod, context);
+      for (const name of missing) {
+        const decl = name.declarations![0];
+        if (decl.getSourceFile().fileName.includes("node_modules")) {
+          continue;
+        }
+        // TODO: maybe handle things other than TypeAliases?
+        if (ts.isTypeAliasDeclaration(decl)) {
+          const sf = decl.getSourceFile();
+          const fileName = sf.fileName;
+          const pos = decl.pos;
+          const converted = context.converter.convertType(context, decl.type);
+          // Depending on whether we have a symbolId or a reflection in
+          // renderType we'll use different keys to look this up.
+          symbolToType.set(`${fileName}:${pos}`, converted);
+          // Ideally we should be able to key on position rather than file and
+          // name when the reflection is present but I couldn't figure out how.
+          symbolToType.set(`${fileName}:${decl.name.getText()}`, converted);
+        }
+      }
+      context.setActiveProgram(void 0);
+    }
+  }
+
+  app.converter.on(Converter.EVENT_RESOLVE_BEGIN, onResolveBegin);
+  return symbolToType;
+}

--- a/sphinx_js/js/typedocPatches.ts
+++ b/sphinx_js/js/typedocPatches.ts
@@ -1,0 +1,7 @@
+/** Declare some extra stuff we monkeypatch on to typedoc */
+
+declare module "typedoc" {
+  export interface TypeDocOptionMap {
+    sphinxJsConfig: string;
+  }
+}

--- a/sphinx_js/js/typedocPlugin.ts
+++ b/sphinx_js/js/typedocPlugin.ts
@@ -1,0 +1,16 @@
+/**
+ * Typedoc plugin which adds --sphinxJsConfig option
+ */
+
+// TODO: we don't seem to resolve imports correctly in this file, but it works
+// to do a dynamic import. Figure out why.
+
+export async function load(app: any) {
+  // @ts-ignore
+  const typedoc = await import("typedoc");
+  app.options.addDeclaration({
+    name: "sphinxJsConfig",
+    help: "[typedoc-plugin-sphinx-js]: the sphinx-js config",
+    type: typedoc.ParameterType.String,
+  });
+}

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -72,7 +72,7 @@ def typedoc_output(
     command.add("--import", str(dir / "registerImportHook.mjs"))
     command.add(str(dir / "call_typedoc.ts"))
     if ts_sphinx_js_config:
-        command.add("--sphinx-js-config", ts_sphinx_js_config)
+        command.add("--sphinxJsConfig", ts_sphinx_js_config)
     command.add("--entryPointStrategy", "expand")
 
     if typedoc_config_path:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -94,7 +94,7 @@ def test_global_install(tmp_path_factory, monkeypatch):
     tmpdir2 = tmp_path_factory.mktemp("blah")
     monkeypatch.setenv("npm_config_prefix", str(tmpdir))
     monkeypatch.setenv("PATH", str(tmpdir / "bin"), prepend=":")
-    subprocess.run(["npm", "i", "-g", "typedoc"])
+    subprocess.run(["npm", "i", "-g", "typedoc", "typescript"])
     typedoc = search_node_modules("typedoc", "typedoc/bin/typedoc", str(tmpdir2))
     monkeypatch.setenv("TYPEDOC_NODE_MODULES", str(Path(typedoc).parents[3]))
     dir = Path(__file__).parents[1].resolve() / "sphinx_js/js"
@@ -111,6 +111,7 @@ def test_global_install(tmp_path_factory, monkeypatch):
         capture_output=True,
         encoding="utf8",
     )
+    print(res.stdout)
     print(res.stderr)
     res.check_returncode()
     assert "TypeDoc 0.25" in res.stdout

--- a/tests/test_typedoc_analysis/source/types.ts
+++ b/tests/test_typedoc_analysis/source/types.ts
@@ -203,3 +203,14 @@ export function namedTupleArg(namedTuple: [key: string, value: any]) {}
 
 export let queryType: typeof A;
 export let typeOperatorType: keyof A;
+
+type PrivateTypeAlias1 = { a: number; b: string };
+
+// Should expand the private type alias
+export let typeIsPrivateTypeAlias1: PrivateTypeAlias1;
+
+/** @private */
+export type PrivateTypeAlias2 = { a: number; b: string };
+
+// Should expand the private type alias
+export let typeIsPrivateTypeAlias2: PrivateTypeAlias2;

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -627,3 +627,11 @@ class TestTypeName(TypeDocAnalyzerTestCase):
     def test_type_operator(self):
         obj = self.analyzer.get_object(["typeOperatorType"])
         assert join_type(obj.type) == "keyof A"
+
+    def test_private_type_alias1(self):
+        obj = self.analyzer.get_object(["typeIsPrivateTypeAlias1"])
+        assert join_type(obj.type) == "{ a: number; b: string; }"
+
+    def test_private_type_alias2(self):
+        obj = self.analyzer.get_object(["typeIsPrivateTypeAlias2"])
+        assert join_type(obj.type) == "{ a: number; b: string; }"


### PR DESCRIPTION
If we have a private type alias that appears in a public function, it generates a broken XRef. This replaces these type references with a reflection containing the original contents. It's a bit involved, we had to add a typedoc plugin based on `typedoc-plugin-missing-exports` to create the missing Reflections