### PR TITLE
Add @hidetype tag to suppress the type of a property

### DIFF
--- a/sphinx_js/js/call_typedoc.ts
+++ b/sphinx_js/js/call_typedoc.ts
@@ -23,7 +23,9 @@ const ExitCodes = {
 
 async function bootstrapAppTypedoc0_25(args: string[]): Promise<Application> {
   return await Application.bootstrapWithPlugins(
-    { plugin: [fileURLToPath(import.meta.resolve("./typedocPlugin.ts"))] },
+    {
+      plugin: [fileURLToPath(import.meta.resolve("./typedocPlugin.ts"))],
+    },
     [
       new ArgumentsReader(0, args),
       new TypeDocReader(),
@@ -53,6 +55,7 @@ async function main() {
     console.log(app.toString());
     return ExitCodes.Ok;
   }
+  app.options.getValue("modifierTags").push("@hidetype");
   const config = await loadConfig(app.options.getValue("sphinxJsConfig"));
   const symbolToType = redirectPrivateTypes(app);
 

--- a/sphinx_js/js/convertTopLevel.ts
+++ b/sphinx_js/js/convertTopLevel.ts
@@ -450,7 +450,12 @@ export class Converter {
     if (!v.type) {
       throw new Error(`Type of ${v.name} is undefined`);
     }
-    const type = this.renderType(v.type);
+    let type: Type;
+    if (v.comment?.modifierTags.has("@hidetype")) {
+      type = [];
+    } else {
+      type = this.renderType(v.type);
+    }
     const result: Attribute = {
       ...this.memberProps(v),
       ...this.topLevelProperties(v),
@@ -517,9 +522,17 @@ export class Converter {
       // way to pick?
       return [this.functionToIR(prop.type.declaration), []];
     }
+    let type: Type;
+    if (prop.comment?.modifierTags.has("@hidetype")) {
+      // We should probably also be able to hide the type of a thing with a
+      // function type literal type...
+      type = [];
+    } else {
+      type = this.renderType(prop.type!);
+    }
     // TODO: add a readonly indicator if it's readonly
     const result: Attribute = {
-      type: this.renderType(prop.type!),
+      type,
       ...this.memberProps(prop),
       ...this.topLevelProperties(prop),
       description: renderCommentSummary(prop.comment),
@@ -651,7 +664,7 @@ export class Converter {
       deppath: filePath.join(""),
       filename: "",
       description: renderCommentSummary(refl.comment),
-      modifier_tags: [],
+      modifier_tags: Array.from(refl.comment?.modifierTags || []),
       block_tags,
       deprecated,
       examples: block_tags["example"] || [],
@@ -660,7 +673,6 @@ export class Converter {
       exported_from: filePath,
       line: refl.sources?.[0].line || null,
       documentation_root: false,
-      // modifier_tags: self.comment.modifierTags,
     };
   }
 

--- a/tests/test_typedoc_analysis/source/types.ts
+++ b/tests/test_typedoc_analysis/source/types.ts
@@ -214,3 +214,17 @@ export type PrivateTypeAlias2 = { a: number; b: string };
 
 // Should expand the private type alias
 export let typeIsPrivateTypeAlias2: PrivateTypeAlias2;
+
+/**
+ * Some comment
+ * @hidetype
+ */
+export let hiddenType: number;
+
+export class HasHiddenTypeMember {
+  /**
+   * Some comment
+   * @hidetype
+   */
+  hasHiddenType: number;
+}

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -635,3 +635,12 @@ class TestTypeName(TypeDocAnalyzerTestCase):
     def test_private_type_alias2(self):
         obj = self.analyzer.get_object(["typeIsPrivateTypeAlias2"])
         assert join_type(obj.type) == "{ a: number; b: string; }"
+
+    def test_hidden_type_top_level(self):
+        obj = self.analyzer.get_object(["hiddenType"])
+        assert obj.modifier_tags == ["@hidetype"]
+        assert obj.type == []
+
+    def test_hidden_type_member(self):
+        obj = self.analyzer.get_object(["HasHiddenTypeMember"])
+        assert obj.members[0].type == []


### PR DESCRIPTION
Some things with complex types can be a bit of an eyesore and we want to hide
them. In the future it could be nice to have a way to replace the type with
a specified string but this is good enough for now.