### PR TITLE
Use Type as the type in IR for extends/implements instead of a path

### DIFF
--- a/sphinx_js/ir.py
+++ b/sphinx_js/ir.py
@@ -298,7 +298,7 @@ class _MembersAndSupers:
     members: list[Function | Attribute]
     #: Objects this one extends: for example, superclasses of a class or
     #: superinterfaces of an interface
-    supers: list[Pathname]
+    supers: list[Type]
 
 
 @define
@@ -317,7 +317,7 @@ class Class(TopLevel, _MembersAndSupers):
     #: Whether this is an abstract class
     is_abstract: bool
     #: Interfaces this class implements
-    interfaces: list[Pathname]
+    interfaces: list[Type]
     # There's room here for additional fields like @example on the class doclet
     # itself. These are supported and extracted by jsdoc, but they end up in an
     # `undocumented: True` doclet and so are presently filtered out. But we do

--- a/sphinx_js/js/convertTopLevel.ts
+++ b/sphinx_js/js/convertTopLevel.ts
@@ -4,6 +4,7 @@ import {
   DeclarationReflection,
   ParameterReflection,
   ProjectReflection,
+  ReferenceType,
   ReflectionKind,
   ReflectionVisitor,
   SignatureReflection,
@@ -11,7 +12,7 @@ import {
   TypeContext,
   TypeParameterReflection,
 } from "typedoc";
-import { renderType } from "./renderType.ts";
+import { referenceToXRef, renderType } from "./renderType.ts";
 import {
   NO_DEFAULT,
   Attribute,
@@ -28,6 +29,8 @@ import {
   TopLevel,
   Type,
   TypeParam,
+  TypeXRefInternal,
+  TypeXRefExternal,
 } from "./ir.ts";
 import { sep, relative } from "path";
 import { SphinxJsConfig } from "./sphinxJsConfig.ts";
@@ -364,6 +367,15 @@ export class Converter {
     );
   }
 
+  referenceToXRef(type: ReferenceType): Type {
+    return referenceToXRef(
+      this.basePath,
+      this.pathMap,
+      this.symbolToType,
+      type,
+    );
+  }
+
   computePaths() {
     this.project.visit(
       new PathComputer(
@@ -472,14 +484,14 @@ export class Converter {
   relatedTypes(
     cls: DeclarationReflection,
     kind: "extendedTypes" | "implementedTypes",
-  ): Pathname[] {
+  ): Type[] {
     const origTypes = cls[kind] || [];
-    const result: Pathname[] = [];
+    const result: Type[] = [];
     for (const t of origTypes) {
       if (t.type !== "reference") {
         continue;
       }
-      result.push(this.pathMap.get(t.reflection as DeclarationReflection)!);
+      result.push(this.referenceToXRef(t));
     }
     return result;
   }

--- a/sphinx_js/js/ir.ts
+++ b/sphinx_js/js/ir.ts
@@ -128,7 +128,7 @@ export type IRFunction = TopLevel &
 
 export type _MembersAndSupers = {
   members: (IRFunction | Attribute)[];
-  supers: Pathname[];
+  supers: Type[];
 };
 
 export type Interface = TopLevel &
@@ -141,7 +141,7 @@ export type Class = TopLevel &
   _MembersAndSupers & {
     constructor_: IRFunction | null;
     is_abstract: boolean;
-    interfaces: Pathname[];
+    interfaces: Type[];
     type_params: TypeParam[];
     kind: "classes";
   };

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -588,11 +588,13 @@ class AutoClassRenderer(JsRenderer):
             exported_from=obj.exported_from,
             class_comment=render_description(obj.description),
             is_abstract=isinstance(obj, Class) and obj.is_abstract,
-            interfaces=obj.interfaces if isinstance(obj, Class) else [],
+            interfaces=[self.render_type(x) for x in obj.interfaces]
+            if isinstance(obj, Class)
+            else [],
             is_interface=isinstance(
                 obj, Interface
             ),  # TODO: Make interfaces not look so much like classes. This will require taking complete control of templating from Sphinx.
-            supers=obj.supers,
+            supers=[self.render_type(x) for x in obj.supers],
             constructor_comment=render_description(constructor.description),
             content="\n".join(self._content),
             members=self._members_of(

--- a/sphinx_js/templates/class.rst
+++ b/sphinx_js/templates/class.rst
@@ -21,14 +21,14 @@
    {% if supers -%}
      **Extends:**
        {% for super in supers -%}
-         - :js:class:`~{{ super.dotted() }}`
+         - {{ super }}
        {% endfor %}
    {%- endif %}
 
    {% if interfaces -%}
      **Implements:**
        {% for interface in interfaces -%}
-         - :js:class:`~{{ interface.dotted() }}`
+         - {{ interface }}
        {% endfor %}
    {%- endif %}
 

--- a/tests/test_build_ts/source/docs/index.rst
+++ b/tests/test_build_ts/source/docs/index.rst
@@ -1,9 +1,9 @@
-.. js:autoclass:: class.ClassDefinition
+.. js:autoclass:: ClassDefinition
    :members:
 
-   This class name includes an explicit "class." prefix so the link from the superclass in autoclass_class_with_interface_and_supers.rst will point here.
+   The link from the superclass in autoclass_class_with_interface_and_supers.rst will point here.
 
-.. js:autoclass:: class.Interface
+.. js:autoclass:: Interface
    :members:
 
    Same here.

--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -328,13 +328,13 @@ class TestHtmlBuilder(SphinxBuildTestCase):
 
     def test_extends_links(self):
         """Make sure superclass mentions link to their definitions."""
-        assert 'href="index.html#class.ClassDefinition"' in self._file_contents(
+        assert 'href="index.html#ClassDefinition"' in self._file_contents(
             "autoclass_class_with_interface_and_supers"
         )
 
     def test_implements_links(self):
         """Make sure implemented interfaces link to their definitions."""
-        assert 'href="index.html#class.Interface"' in self._file_contents(
+        assert 'href="index.html#Interface"' in self._file_contents(
             "autoclass_class_with_interface_and_supers"
         )
 

--- a/tests/test_typedoc_analysis/source/nodes.ts
+++ b/tests/test_typedoc_analysis/source/nodes.ts
@@ -15,6 +15,10 @@ export interface InterfaceWithMembers {
  */
 export abstract class EmptySubclass extends Superclass implements Interface {}
 
+export abstract class EmptySubclass2
+  extends Promise<number>
+  implements Interface {}
+
 export const topLevelConst = 3;
 
 /**

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -211,10 +211,17 @@ class TestConvertNode(TypeDocAnalyzerTestCase):
         assert isinstance(subclass, Class)
         assert subclass.constructor_ is None
         assert subclass.is_abstract
-        assert subclass.interfaces == [Pathname(["./", "nodes.", "Interface"])]
+        assert subclass.interfaces == [
+            [TypeXRefInternal("Interface", ["./", "nodes.", "Interface"])]
+        ]
+
+        subclass2 = self.analyzer.get_object(["EmptySubclass2"])
+        assert join_type(subclass2.supers[0]) == "Promise<number>"
 
         # _MembersAndSupers attrs:
-        assert subclass.supers == [Pathname(["./", "nodes.", "Superclass"])]
+        assert subclass.supers == [
+            [TypeXRefInternal("Superclass", ["./", "nodes.", "Superclass"])]
+        ]
         assert subclass.members == []
 
         # TopLevel attrs. This should cover them for other kinds of objs as
@@ -237,7 +244,9 @@ class TestConvertNode(TypeDocAnalyzerTestCase):
 
         """
         interface = self.analyzer.get_object(["Interface"])
-        assert interface.supers == [Pathname(["./", "nodes.", "SuperInterface"])]
+        assert interface.supers == [
+            [TypeXRefInternal("SuperInterface", ["./", "nodes.", "SuperInterface"])]
+        ]
 
     def test_interface_function_member(self):
         """Make sure function-like properties are understood."""


### PR DESCRIPTION
This makes the cross referencing for types that we extend or implement match the cross referencing for types in other places. In particular it allows us to extend external types.