### PR TITLE
Give interfaces their own autosummary and automodule sections

### DIFF
--- a/sphinx_js/ir.py
+++ b/sphinx_js/ir.py
@@ -202,6 +202,7 @@ class Module:
     attributes: list["TopLevel"] = Factory(list)
     functions: list["Function"] = Factory(list)
     classes: list["Class"] = Factory(list)
+    interfaces: list["Interface"] = Factory(list)
 
 
 @define(slots=False)
@@ -306,7 +307,7 @@ class Interface(TopLevel, _MembersAndSupers):
     """An interface, a la TypeScript"""
 
     type_params: list[TypeParam] = Factory(list)
-    kind: str = "classes"
+    kind: str = "interfaces"
 
 
 @define

--- a/sphinx_js/js/convertTopLevel.ts
+++ b/sphinx_js/js/convertTopLevel.ts
@@ -518,7 +518,7 @@ export class Converter {
       supers: this.relatedTypes(cls, "extendedTypes"),
       type_params: this.typeParamsToIR(cls.typeParameters),
       ...this.topLevelProperties(cls),
-      kind: "classes",
+      kind: "interfaces",
     };
     return [result, cls.children];
   }

--- a/sphinx_js/js/ir.ts
+++ b/sphinx_js/js/ir.ts
@@ -134,7 +134,7 @@ export type _MembersAndSupers = {
 export type Interface = TopLevel &
   _MembersAndSupers & {
     type_params: TypeParam[];
-    kind: "classes";
+    kind: "interfaces";
   };
 
 export type Class = TopLevel &

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -333,7 +333,7 @@ class JsRenderer(Renderer):
                 renderer_class = AutoAttributeRenderer
             case Function(_):
                 renderer_class = AutoFunctionRenderer
-            case Class(_):
+            case Class(_) | Interface(_):
                 renderer_class = AutoClassRenderer
             case _:
                 raise RuntimeError("This shouldn't happen...")
@@ -676,6 +676,7 @@ class AutoModuleRenderer(JsRenderer):
         rst.append(self.rst_for_group(obj.attributes))
         rst.append(self.rst_for_group(obj.functions))
         rst.append(self.rst_for_group(obj.classes))
+        rst.append(self.rst_for_group(obj.interfaces))
         return "\n\n".join(["\n\n".join(r) for r in rst])
 
 
@@ -699,6 +700,7 @@ class AutoSummaryRenderer(Renderer):
             ("attributes", module.attributes),
             ("functions", module.functions),
             ("classes", module.classes),
+            ("interfaces", module.interfaces),
         ]
         pkgname = "".join(self._partial_path)
 

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -169,4 +169,5 @@ class Analyzer:
             mod.attributes = sorted(mod.attributes, key=attrgetter("name"))
             mod.functions = sorted(mod.functions, key=attrgetter("name"))
             mod.classes = sorted(mod.classes, key=attrgetter("name"))
+            mod.interfaces = sorted(mod.interfaces, key=attrgetter("name"))
         return modules.values()

--- a/tests/test_build_ts/source/module.ts
+++ b/tests/test_build_ts/source/module.ts
@@ -36,3 +36,8 @@ export class Z {
  * Another thing.
  */
 export const q = { a: "z29", b: 76 };
+
+/**
+ * Interface documentation
+ */
+export interface I {}

--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -315,6 +315,14 @@ class TestTextBuilder(SphinxBuildTestCase):
                       type: number
 
                    Z.z()
+
+                class module.I()
+
+                   Interface documentation
+
+                   *interface*
+
+                   *exported from* "module"
                 """
             ),
         )
@@ -412,3 +420,6 @@ class TestHtmlBuilder(SphinxBuildTestCase):
 
         classes = soup.find(class_="classes")
         assert classes.find(class_="summary").get_text() == "This is a summary."
+
+        classes = soup.find(class_="interfaces")
+        assert classes.find(class_="summary").get_text() == "Interface documentation"


### PR DESCRIPTION
Prior to this, we crash if we run automodule on a module that exports an interface. This fix automodule for exported interfaces and adds a new section to automodule and autosummary for these.