### PR TITLE
Add a separate directive for interfaces than for classes

### DIFF
--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -5,15 +5,12 @@ from textwrap import dedent
 from typing import Any
 
 from sphinx.application import Sphinx
+from sphinx.domains.javascript import JavaScriptDomain
 from sphinx.errors import SphinxError
 
 from .directives import (
     JSFunction,
-    auto_attribute_directive_bound_to_app,
-    auto_class_directive_bound_to_app,
-    auto_function_directive_bound_to_app,
-    auto_module_directive_bound_to_app,
-    auto_summary_directive_bound_to_app,
+    add_directives,
     sphinx_js_type_role,
 )
 from .jsdoc import Analyzer as JsAnalyzer
@@ -94,7 +91,6 @@ def fix_staticfunction_objtype() -> None:
     """Override js:function directive with one that understands static and async
     prefixes
     """
-    from sphinx.domains.javascript import JavaScriptDomain
 
     JavaScriptDomain.directives["function"] = JSFunction
 
@@ -153,21 +149,7 @@ def setup(app: Sphinx) -> None:
     # is RSTs.
     app.connect("builder-inited", analyze)
 
-    app.add_directive_to_domain(
-        "js", "autofunction", auto_function_directive_bound_to_app(app)
-    )
-    app.add_directive_to_domain(
-        "js", "autoclass", auto_class_directive_bound_to_app(app)
-    )
-    app.add_directive_to_domain(
-        "js", "autoattribute", auto_attribute_directive_bound_to_app(app)
-    )
-    app.add_directive_to_domain(
-        "js", "automodule", auto_module_directive_bound_to_app(app)
-    )
-    app.add_directive_to_domain(
-        "js", "autosummary", auto_summary_directive_bound_to_app(app)
-    )
+    add_directives(app)
 
     # TODO: We could add a js:module with app.add_directive_to_domain().
 

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -591,9 +591,7 @@ class AutoClassRenderer(JsRenderer):
             interfaces=[self.render_type(x) for x in obj.interfaces]
             if isinstance(obj, Class)
             else [],
-            is_interface=isinstance(
-                obj, Interface
-            ),  # TODO: Make interfaces not look so much like classes. This will require taking complete control of templating from Sphinx.
+            is_interface=isinstance(obj, Interface),
             supers=[self.render_type(x) for x in obj.supers],
             constructor_comment=render_description(constructor.description),
             content="\n".join(self._content),

--- a/sphinx_js/templates/class.rst
+++ b/sphinx_js/templates/class.rst
@@ -1,6 +1,10 @@
 {% import 'common.rst' as common %}
 
+{% if is_interface -%}
+.. js:interface:: {{ name }}{{ params }}
+{%- else -%}
 .. js:class:: {{ name }}{{ params }}
+{%- endif %}
 
    {{ common.deprecated(deprecated)|indent(3) }}
 
@@ -10,10 +14,6 @@
 
    {% if is_abstract -%}
      *abstract*
-   {%- endif %}
-
-   {% if is_interface -%}
-     *interface*
    {%- endif %}
 
    {{ common.exported_from(exported_from)|indent(3) }}

--- a/tests/test_build_ts/source/module.ts
+++ b/tests/test_build_ts/source/module.ts
@@ -38,6 +38,6 @@ export class Z {
 export const q = { a: "z29", b: 76 };
 
 /**
- * Interface documentation
+ * Documentation for the interface I
  */
 export interface I {}

--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -93,9 +93,7 @@ class TestTextBuilder(SphinxBuildTestCase):
         question marks sticking out of them."""
         self._file_contents_eq(
             "autoclass_interface_optionals",
-            "class OptionalThings()\n"
-            "\n"
-            "   *interface*\n"
+            "interface OptionalThings()\n"
             "\n"
             '   *exported from* "class"\n'
             "\n"
@@ -316,11 +314,9 @@ class TestTextBuilder(SphinxBuildTestCase):
 
                    Z.z()
 
-                class module.I()
+                interface module.I()
 
-                   Interface documentation
-
-                   *interface*
+                   Documentation for the interface I
 
                    *exported from* "module"
                 """
@@ -422,4 +418,7 @@ class TestHtmlBuilder(SphinxBuildTestCase):
         assert classes.find(class_="summary").get_text() == "This is a summary."
 
         classes = soup.find(class_="interfaces")
-        assert classes.find(class_="summary").get_text() == "Interface documentation"
+        assert (
+            classes.find(class_="summary").get_text()
+            == "Documentation for the interface I"
+        )


### PR DESCRIPTION
This adds a `:js:interface:` directive so that interfaces get their own distinct
prefix and index entries. Otherwise, we still render them identically to
classes but it's not clear that there is a downside to this.