### PR TITLE
Add more sphinxJsConfig hooks

### DIFF
--- a/sphinx_js/js/convertTopLevel.ts
+++ b/sphinx_js/js/convertTopLevel.ts
@@ -29,8 +29,6 @@ import {
   TopLevel,
   Type,
   TypeParam,
-  TypeXRefInternal,
-  TypeXRefExternal,
 } from "./ir.ts";
 import { sep, relative } from "path";
 import { SphinxJsConfig } from "./sphinxJsConfig.ts";
@@ -341,6 +339,7 @@ export class Converter {
     Pathname
   >;
   readonly documentationRoots: Set<DeclarationReflection | SignatureReflection>;
+  readonly typedocToIRMap: Map<DeclarationReflection, TopLevel>;
 
   constructor(
     project: ProjectReflection,
@@ -352,9 +351,11 @@ export class Converter {
     this.basePath = basePath;
     this.config = config;
     this.symbolToType = symbolToType;
+
     this.pathMap = new Map();
     this.filePathMap = new Map();
     this.documentationRoots = new Set();
+    this.typedocToIRMap = new Map();
   }
 
   renderType(type: SomeType, context: TypeContext = TypeContext.none): Type {
@@ -397,6 +398,7 @@ export class Converter {
       const node = todo.pop()!;
       const [converted, rest] = this.toIr(node);
       if (converted) {
+        this.typedocToIRMap.set(node, converted);
         result.push(converted);
       }
       todo.push(...(rest || []));

--- a/sphinx_js/js/redirectPrivateAliases.ts
+++ b/sphinx_js/js/redirectPrivateAliases.ts
@@ -101,13 +101,17 @@ export function redirectPrivateTypes(app: Application): ReadonlySymbolToType {
   }
 
   const origCreateSymbolReference = ReferenceType.createSymbolReference;
-  ReferenceType.createSymbolReference = function (symbol, context, name) {
+  ReferenceType.createSymbolReference = function (
+    symbol: ts.Symbol,
+    context: Context,
+    name: string,
+  ) {
     const owningModule = getOwningModule(context);
     getReferencedSymbols(owningModule).add(symbol);
     return origCreateSymbolReference.call(this, symbol, context, name);
   };
 
-  function onResolveBegin(context: Context) {
+  function onResolveBegin(context: Context): void {
     const modules: (DeclarationReflection | ProjectReflection)[] =
       context.project.getChildrenByKind(ReflectionKind.Module);
     if (modules.length === 0) {

--- a/sphinx_js/js/sphinxJsConfig.ts
+++ b/sphinx_js/js/sphinxJsConfig.ts
@@ -1,5 +1,17 @@
-import { ParameterReflection } from "typedoc";
+import {
+  Application,
+  DeclarationReflection,
+  ParameterReflection,
+  ProjectReflection,
+} from "typedoc";
+import { TopLevel } from "./ir.ts";
 
 export type SphinxJsConfig = {
-  shouldDestructureArg?: (p: ParameterReflection) => boolean;
+  shouldDestructureArg?: (param: ParameterReflection) => boolean;
+  preConvert?: (app: Application) => Promise<void>;
+  postConvert?: (
+    app: Application,
+    project: ProjectReflection,
+    typedocToIRMap: ReadonlyMap<DeclarationReflection, TopLevel>,
+  ) => Promise<void>;
 };

--- a/sphinx_js/js/typedocPatches.ts
+++ b/sphinx_js/js/typedocPatches.ts
@@ -1,7 +1,11 @@
 /** Declare some extra stuff we monkeypatch on to typedoc */
-
 declare module "typedoc" {
   export interface TypeDocOptionMap {
     sphinxJsConfig: string;
+  }
+  export interface Application {
+    extraData: {
+      [key: string]: any;
+    };
   }
 }

--- a/sphinx_js/js/typedocPlugin.ts
+++ b/sphinx_js/js/typedocPlugin.ts
@@ -5,7 +5,7 @@
 // TODO: we don't seem to resolve imports correctly in this file, but it works
 // to do a dynamic import. Figure out why.
 
-export async function load(app: any) {
+export async function load(app: any): Promise<void> {
   // @ts-ignore
   const typedoc = await import("typedoc");
   app.options.addDeclaration({

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -82,7 +82,7 @@ class TypeDocTestCase(ThisDirTestCase):
 
         config_file = Path(__file__).parent / "sphinxJsConfig.ts"
 
-        cls.json = typedoc_output(
+        [cls.json, cls.extra_data] = typedoc_output(
             abs_source_paths=[join(cls._source_dir, file) for file in cls.files],
             base_dir=cls._source_dir,
             ts_sphinx_js_config=str(config_file),
@@ -103,7 +103,7 @@ class TypeDocAnalyzerTestCase(TypeDocTestCase):
         def should_destructure(sig, p):
             return p.name == "destructureThisPlease"
 
-        cls.analyzer = TsAnalyzer(cls.json, cls._source_dir)
+        cls.analyzer = TsAnalyzer(cls.json, cls.extra_data, cls._source_dir)
 
 
 NO_MATCH = object()


### PR DESCRIPTION
I added hooks preConvert and postConvert. preConvert receives just the typedoc app and runs right after application bootstrap. (To run earlier I think you'd need to make an actual typedoc plugin). `postConvert` runs right at the end. I also added a map from typedoc reflections to the corresponding ir item that postConvert can look at. I also added an extra_data dictionary which we pass to Python so that implementations of these hooks can pass extra information to be handled on the Pythons side. (None of the Python-side hooks can use this info yet, it can only be used via a monkeypatch.)

No test coverage for any of this...