### PR TITLE
NFC tidy up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ venv
 .venv
 coverage.xml
 test-results.xml
+node_modules
+tsconfig.tsbuildinfo


### PR DESCRIPTION
Use `refl.kindOf` instead of comparing value of `refl.kind` which is a bit tidier. Rename `renderType` to `convertType` to keep terminology more consistent. Update `.gitignore`.