### PR TITLE
Fix interface xrefs

### DIFF
--- a/sphinx_js/directives.py
+++ b/sphinx_js/directives.py
@@ -27,6 +27,7 @@ from sphinx.domains.javascript import (
     JSCallable,
     JSConstructor,
     JSObject,
+    JSXRefRole,
 )
 from sphinx.locale import _
 from sphinx.util.docfields import GroupedField, TypedField
@@ -291,7 +292,7 @@ class JSInterface(JSCallable):
 
 
 @cache
-def patch_js_interface() -> None:
+def patch_JsObject_get_index_text() -> None:
     orig_get_index_text = JSObject.get_index_text
 
     def patched_get_index_text(
@@ -303,12 +304,6 @@ def patch_js_interface() -> None:
         return orig_get_index_text(self, objectname, name_obj)
 
     JSObject.get_index_text = patched_get_index_text  # type:ignore[method-assign]
-
-
-def add_js_interface(app: Sphinx) -> None:
-    patch_js_interface()
-    JavaScriptDomain.object_types["interface"] = ObjType(_("interface"), "interface")
-    app.add_directive_to_domain("js", "interface", JSInterface)
 
 
 def auto_module_directive_bound_to_app(app: Sphinx) -> type[Directive]:
@@ -337,6 +332,7 @@ def add_directives(app: Sphinx) -> None:
     fix_js_make_xref()
     fix_staticfunction_objtype()
     add_type_param_field_to_directives()
+    patch_JsObject_get_index_text()
     app.add_role("sphinx_js_type", sphinx_js_type_role)
     app.add_directive_to_domain(
         "js", "autofunction", auto_function_directive_bound_to_app(app)
@@ -353,4 +349,6 @@ def add_directives(app: Sphinx) -> None:
     app.add_directive_to_domain(
         "js", "autosummary", auto_summary_directive_bound_to_app(app)
     )
-    add_js_interface(app)
+    JavaScriptDomain.object_types["interface"] = ObjType(_("interface"), "interface")
+    app.add_directive_to_domain("js", "interface", JSInterface)
+    app.add_role_to_domain("js", "interface", JSXRefRole())

--- a/tests/test_build_ts/source/docs/conf.py
+++ b/tests/test_build_ts/source/docs/conf.py
@@ -14,9 +14,9 @@ from sphinx.util import rst
 from sphinx_js.ir import TypeXRefInternal
 
 
-def ts_type_xref_formatter(config, xref):
+def ts_type_xref_formatter(config, xref, kind):
     if isinstance(xref, TypeXRefInternal):
         name = rst.escape(xref.name)
-        return f":js:class:`{name}`"
+        return f":js:{kind}:`{name}`"
     else:
         return xref.name

--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -63,7 +63,7 @@ class TestTextBuilder(SphinxBuildTestCase):
             '      * "ClassDefinition()"\n'
             "\n"
             "   **Implements:**\n"
-            '      * "Interface()"\n'
+            '      * "Interface"\n'
             "\n"
             "   I construct.\n",
         )
@@ -354,7 +354,7 @@ class TestHtmlBuilder(SphinxBuildTestCase):
         assert href.attrs["href"] == "autoclass_interface_optionals.html#OptionalThings"
         assert href.attrs["title"] == "OptionalThings"
         assert next(href.children).name == "code"
-        assert href.get_text() == "OptionalThings()"
+        assert href.get_text() == "OptionalThings"
 
         href = links[2]
         assert href.attrs["class"] == ["reference", "internal"]
@@ -364,7 +364,7 @@ class TestHtmlBuilder(SphinxBuildTestCase):
         assert href.get_text() == "ConstructorlessClass()"
 
         thunk_links = get_links("thunk")
-        assert thunk_links[1].get_text() == "OptionalThings()"
+        assert thunk_links[1].get_text() == "OptionalThings"
         assert thunk_links[2].get_text() == "ConstructorlessClass()"
 
     def test_sphinx_link_in_description(self):


### PR DESCRIPTION
This adds a role for interface cross referencing. It also updates `ts_type_xref_formatter` to take a third argument "kind" which indicates which type of object we're referring to so that we can generate proper xrefs. 
TODO: We should probably move this field onto the XRefInternal object.

This also removes the parens interface xrefs since they don't really make sense.