### PR TITLE
Move the way that we render extends bound on type parameter

### DIFF
--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -467,10 +467,11 @@ class JsRenderer(Renderer):
 
     def _type_param_formatter(self, tparam: TypeParam) -> tuple[list[str], str] | None:
         v = tparam.name
+        descr = render_description(tparam.description)
         if tparam.extends:
-            v += " extends " + self.render_type(tparam.extends)
+            descr += " (extends " + self.render_type(tparam.extends) + ")"
         heads = ["typeparam", v]
-        return heads, render_description(tparam.description)
+        return heads, descr
 
     def _param_formatter(self, param: Param) -> tuple[list[str], str] | None:
         """Derive heads and tail from ``@param`` blocks."""

--- a/tests/test_build_ts/source/module.ts
+++ b/tests/test_build_ts/source/module.ts
@@ -25,8 +25,11 @@ export class A {
   }
 }
 
-export class Z {
-  x: number;
+/**
+ * @typeParam T Description of T
+ */
+export class Z<T extends A> {
+  x: T;
   constructor(a: number, b: number) {}
 
   z() {}

--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -304,7 +304,7 @@ class TestTextBuilder(SphinxBuildTestCase):
                    *exported from* "module"
 
                    Type parameters:
-                      **T** -- (extends "A()")
+                      **T** -- Description of T (extends "A()")
 
                    Arguments:
                       * **a** (number)

--- a/tests/test_typedoc_analysis/test_typedoc_analysis.py
+++ b/tests/test_typedoc_analysis/test_typedoc_analysis.py
@@ -501,7 +501,8 @@ class TestTypeName(TypeDocAnalyzerTestCase):
         rst = rst.replace("\\", "").replace("  ", " ")
         assert ":typeparam T: The type of the object" in rst
         assert (
-            ":typeparam K extends string | number | symbol: The type of the key" in rst
+            ":typeparam K: The type of the key (extends string | number | symbol)"
+            in rst
         )
 
     def test_class_constrained(self):
@@ -522,7 +523,7 @@ class TestTypeName(TypeDocAnalyzerTestCase):
         a._options = {}
         rst = a.rst([obj.name], obj)
         rst = rst.replace("\\ ", "").replace("\\", "").replace("  ", " ")
-        assert ":typeparam S extends number[]: The type we contain" in rst
+        assert ":typeparam S: The type we contain (extends number[])" in rst
 
     def test_constrained_by_constructor(self):
         """Make sure ``new ()`` expressions and, more generally, per-property

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -43,6 +43,7 @@ class SphinxBuildTestCase(ThisDirTestCase):
 
     @classmethod
     def teardown_class(cls):
+        return
         rmtree(join(cls.docs_dir, "_build"))
 
     def _file_contents(self, filename):

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -43,7 +43,6 @@ class SphinxBuildTestCase(ThisDirTestCase):
 
     @classmethod
     def teardown_class(cls):
-        return
         rmtree(join(cls.docs_dir, "_build"))
 
     def _file_contents(self, filename):


### PR DESCRIPTION
It didn't work correctly before because the description list label does not render rst.