### PR TITLE
Label readonly properties in the docs

### DIFF
--- a/sphinx_js/ir.py
+++ b/sphinx_js/ir.py
@@ -274,6 +274,7 @@ class Attribute(TopLevel, _Member):
 
     #: The type this property's value can have
     type: Type
+    readonly: bool = False
     kind: Literal["attribute"] = "attribute"
 
 

--- a/sphinx_js/js/convertTopLevel.ts
+++ b/sphinx_js/js/convertTopLevel.ts
@@ -471,6 +471,7 @@ export class Converter {
     const result: Attribute = {
       ...this.memberProps(v),
       ...this.topLevelProperties(v),
+      readonly: false,
       kind: "attribute",
       type,
     };
@@ -542,12 +543,12 @@ export class Converter {
     } else {
       type = this.convertType(prop.type!);
     }
-    // TODO: add a readonly indicator if it's readonly
     const result: Attribute = {
       type,
       ...this.memberProps(prop),
       ...this.topLevelProperties(prop),
       description: renderCommentSummary(prop.comment),
+      readonly: prop.flags.isReadonly,
       kind: "attribute",
     };
     return [result, prop.children];
@@ -581,9 +582,11 @@ export class Converter {
       sig = prop.setSignature;
       type = sig.parameters![0].type!;
     }
-    // TODO: add a readonly indicator if there's no setter.
+    // If there's no setter say it's readonly
+    const readonly = !prop.setSignature;
     const result: Attribute = {
       type: this.convertType(type),
+      readonly,
       ...this.memberProps(prop),
       ...this.topLevelProperties(prop),
       kind: "attribute",

--- a/sphinx_js/js/ir.ts
+++ b/sphinx_js/js/ir.ts
@@ -113,6 +113,7 @@ export type TopLevel = {
 export type Attribute = TopLevel &
   Member & {
     type: Type;
+    readonly: boolean;
     kind: "attribute";
   };
 

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -657,8 +657,11 @@ class AutoAttributeRenderer(JsRenderer):
 
     def _template_vars(self, name: str, obj: Attribute | TypeAlias) -> dict[str, Any]:  # type: ignore[override]
         is_optional = False
+        ty = self.render_type(obj.type)
         if isinstance(obj, Attribute):
             is_optional = obj.is_optional
+            if obj.readonly:
+                ty = "readonly " + ty
         type_params = ""
         is_type_alias = isinstance(obj, TypeAlias)
         fields: Iterator[tuple[list[str], str]] = iter([])
@@ -675,7 +678,7 @@ class AutoAttributeRenderer(JsRenderer):
             is_optional=is_optional,
             see_also=obj.see_alsos,
             examples=[render_description(ex) for ex in obj.examples],
-            type=self.render_type(obj.type),
+            type=ty,
             content="\n".join(self._content),
         )
 

--- a/tests/test_build_ts/source/class.ts
+++ b/tests/test_build_ts/source/class.ts
@@ -109,6 +109,9 @@ export function weirdCodeInDescription() {}
 export function spinxLinkInDescription() {}
 
 export class GetSetDocs {
+  readonly x: number;
+  y: number;
+
   /**
    * Getter with comment
    */
@@ -119,7 +122,7 @@ export class GetSetDocs {
   /**
    * Setter with comment
    */
-  set b(x) {}
+  set b(x: number) {}
 }
 
 export class Base {

--- a/tests/test_build_ts/test_build_ts.py
+++ b/tests/test_build_ts/test_build_ts.py
@@ -193,21 +193,29 @@ class TestTextBuilder(SphinxBuildTestCase):
             "getset",
             dedent(
                 """\
-                class GetSetDocs()
+class GetSetDocs()
 
-                   *exported from* "class"
+   *exported from* "class"
 
-                   GetSetDocs.a
+   GetSetDocs.a
 
-                      type: number
+      type: readonly number
 
-                      Getter with comment
+      Getter with comment
 
-                   GetSetDocs.b
+   GetSetDocs.b
 
-                      type: any
+      type: number
 
-                      Setter with comment
+      Setter with comment
+
+   GetSetDocs.x
+
+      type: readonly number
+
+   GetSetDocs.y
+
+      type: number
                 """
             ),
         )
@@ -224,7 +232,7 @@ class TestTextBuilder(SphinxBuildTestCase):
 
                    Base.a
 
-                      type: number
+                      type: readonly number
 
                    Base.f()
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -59,6 +59,7 @@ attribute_base = Attribute(
     is_optional=False,
     is_static=False,
     is_private=False,
+    readonly=False,
     type=[]
 )
 attr_dict = {k: v for k, v in getmembers(attribute_base) if not k.startswith("_")}


### PR DESCRIPTION
If it is an accessor with a getter but no setter or if it's a normal property with a readonly type, show it as readonly.