### PR TITLE
Move the xref kind arg onto a field of the TypeXRefInternal

### DIFF
--- a/sphinx_js/ir.py
+++ b/sphinx_js/ir.py
@@ -45,6 +45,7 @@ class TypeXRefInternal:
     name: str
     path: list[str]
     type: Literal["internal"] = "internal"
+    kind: str | None = None
 
 
 @define

--- a/sphinx_js/js/convertType.ts
+++ b/sphinx_js/js/convertType.ts
@@ -297,7 +297,6 @@ class TypeConverter implements TypeVisitor<Type> {
   }
 
   reference(type: ReferenceType): Type {
-    let res;
     if (type.isIntentionallyBroken()) {
       // If it's intentionally broken, don't add an xref. It's probably a type
       // parameter.
@@ -305,7 +304,7 @@ class TypeConverter implements TypeVisitor<Type> {
     } else {
       // if we got a reflection use that. It's not all that clear how to deal
       // with type arguments here though...
-      res = this.convertPrivateReferenceToReflection(type);
+      const res = this.convertPrivateReferenceToReflection(type);
       // else use convertReferenceToXRef
       if (res) {
         return res;

--- a/tests/test_build_ts/source/docs/conf.py
+++ b/tests/test_build_ts/source/docs/conf.py
@@ -14,9 +14,9 @@ from sphinx.util import rst
 from sphinx_js.ir import TypeXRef, TypeXRefInternal
 
 
-def ts_type_xref_formatter(config, xref: TypeXRef, kind: str) -> str:
+def ts_type_xref_formatter(config, xref: TypeXRef) -> str:
     if isinstance(xref, TypeXRefInternal):
         name = rst.escape(xref.name)
-        return f":js:{kind}:`{name}`"
+        return f":js:{xref.kind}:`{name}`"
     else:
         return xref.name

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -60,10 +60,10 @@ def test_render_description():
     )
 
 
-def ts_xref_formatter(config, xref, kind):
+def ts_xref_formatter(config, xref):
     if isinstance(xref, TypeXRefInternal):
         name = rst.escape(xref.name)
-        return f":js:{kind}:`{name}`"
+        return f":js:{xref.kind}:`{name}`"
     else:
         return xref.name
 
@@ -339,8 +339,12 @@ def test_render_xref(function_renderer: AutoFunctionRenderer):
     assert function_renderer.render_type([xref_external]) == "A"
     res = []
 
-    def xref_render(config, val, kind):
+    def xref_render(config, val):
         res.append([config, val])
+        kind = None
+        if isinstance(val, TypeXRefInternal):
+            kind = val.kind
+
         return f"{val.package}::{val.name}::{kind}"
 
     function_renderer._set_type_xref_formatter(xref_render)


### PR DESCRIPTION
This field is always `None` unless the argument is a `TypeXRefInternal` so it makes more sense to put it as a field.