### PR TITLE
If we fail to find the object given by path, catch the error

### DIFF
--- a/sphinx_js/js/convertType.ts
+++ b/sphinx_js/js/convertType.ts
@@ -287,6 +287,8 @@ class TypeConverter implements TypeVisitor<Type> {
       };
       return this.addTypeArguments(type, [xref]);
     } else {
+      // TODO: I'm not sure that it's right to generate an internal xref here.
+      // We need better test coverage for this code path.
       const xref: TypeXRefInternal = {
         name: type.name,
         path,

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -454,11 +454,18 @@ class JsRenderer(Renderer):
     def render_xref(self, s: TypeXRef, escape: bool = False) -> str:
         obj = None
         if isinstance(s, TypeXRefInternal):
-            obj = self.lookup_object(s.path)
-            # Stick the kind on the xref so that the formatter will know what
-            # xref role to emit. I'm not sure how to compute this earlier. It's
-            # convenient to do it here.
-            s.kind = type(obj).__name__.lower()
+            try:
+                obj = self.lookup_object(s.path)
+                # Stick the kind on the xref so that the formatter will know what
+                # xref role to emit. I'm not sure how to compute this earlier. It's
+                # convenient to do it here.
+                s.kind = type(obj).__name__.lower()
+            except SphinxError:
+                # This sometimes happens on the code path in
+                # convertReferenceToXRef when we generate an xref internal from
+                # a symbolId. That code path is probably entirely wrong.
+                # TODO: fix and add test coverage.
+                pass
         result = self._type_xref_formatter(s)
         if escape:
             result = rst.escape(result)


### PR DESCRIPTION
This corresponds to some slightly weird code paths in convertReferenceToXRef. I think in this case we shouldn't have generated an internal xref. Ideally we'd fix them but I don't know how yet.