### PR TITLE
Allow ruff to lint for Python syntax errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,7 @@ select = [
   "I",     # isort
   "PGH",   # pygrep-hooks
 ]
-# Remove E999 once pattern matching is supported
-# https://github.com/charliermarsh/ruff/issues/282
-ignore = ["E402", "E501", "E731", "E741", "E999", "B904", "B020"]
+ignore = ["E402", "E501", "E731", "E741", "B904", "B020"]
 target-version = "py310"
 
 [tool.ruff.flake8-bugbear]


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/syntax-error
* https://github.com/astral-sh/ruff/issues/282 (closed)
* https://docs.astral.sh/ruff/rules/syntax-error