### PR TITLE
setup.py: Upgrade to markupsafe==3.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,7 @@ setup(
         "Jinja2>2.0",
         "parsimonious>=0.10.0,<0.11.0",
         "Sphinx>=4.1.0",
-        # Pin markupsafe because of
-        # https://github.com/pallets/jinja/issues/1585
-        "markupsafe==2.0.1",
+        "markupsafe==3.0.2",
         "attrs",
         "cattrs",
     ],

--- a/sphinx_js/directives.py
+++ b/sphinx_js/directives.py
@@ -33,8 +33,8 @@ from sphinx.domains.javascript import (
 from sphinx.locale import _
 from sphinx.util.docfields import GroupedField, TypedField
 from sphinx.writers.html5 import HTML5Translator
-from sphinx.writers.text import TextTranslator
 from sphinx.writers.latex import LaTeXTranslator
+from sphinx.writers.text import TextTranslator
 
 from .renderers import (
     AutoAttributeRenderer,
@@ -328,11 +328,15 @@ def text_depart_desc_js_type_parameter_list(
     self.add_text(">")
 
 
-def latex_visit_desc_type_parameter_list(self: LaTeXTranslator, node: nodes.Element) -> None:
+def latex_visit_desc_type_parameter_list(
+    self: LaTeXTranslator, node: nodes.Element
+) -> None:
     pass
 
 
-def latex_depart_desc_type_parameter_list(self: LaTeXTranslator, node: nodes.Element) -> None:
+def latex_depart_desc_type_parameter_list(
+    self: LaTeXTranslator, node: nodes.Element
+) -> None:
     pass
 
 


### PR DESCRIPTION
```diff
-        # Pin markupsafe because of
-        # https://github.com/pallets/jinja/issues/1585
-        "markupsafe==2.0.1",
+        "markupsafe==3.0.2",
```
https://pypi.org/project/MarkupSafe

https://github.com/pyodide/sphinx-js-fork/pulls/cclauss