### PR TITLE
Split call_typedoc into main.ts and cli.ts. NFC

### DIFF
--- a/sphinx_js/js/cli.ts
+++ b/sphinx_js/js/cli.ts
@@ -5,11 +5,11 @@ import {
   PackageJsonReader,
   TSConfigReader,
 } from "typedoc";
-import { writeFile } from "fs/promises";
 import { Converter } from "./convertTopLevel.ts";
 import { SphinxJsConfig } from "./sphinxJsConfig.ts";
 import { fileURLToPath } from "url";
 import { redirectPrivateTypes } from "./redirectPrivateAliases.ts";
+import { TopLevelIR } from "./ir.ts";
 
 const ExitCodes = {
   Ok: 0,
@@ -36,6 +36,14 @@ async function bootstrapAppTypedoc0_25(args: string[]): Promise<Application> {
   );
 }
 
+export class ExitError extends Error {
+  code: number;
+  constructor(code: number) {
+    super();
+    this.code = code;
+  }
+}
+
 async function loadConfig(
   configPath: string | undefined,
 ): Promise<SphinxJsConfig> {
@@ -46,17 +54,16 @@ async function loadConfig(
   return configModule.config;
 }
 
-async function main() {
+export async function run(args: string[]): Promise<[Application, TopLevelIR[]]> {
   // Most of this stuff is copied from typedoc/src/lib/cli.ts
-  const start = Date.now();
-  const args = process.argv.slice(2);
   let app = await bootstrapAppTypedoc0_25(args);
   if (app.options.getValue("version")) {
     console.log(app.toString());
-    return ExitCodes.Ok;
+    throw new ExitError(ExitCodes.Ok);
   }
   app.extraData = {};
   app.options.getValue("modifierTags").push("@hidetype");
+  app.options.getValue("blockTags").push("@destructure");
   const userConfigPath = app.options.getValue("sphinxJsConfig");
   const config = await loadConfig(userConfigPath);
   app.logger.info(`Loaded user config from ${userConfigPath}`);
@@ -65,34 +72,27 @@ async function main() {
 
   const project = await app.convert();
   if (!project) {
-    return ExitCodes.CompileError;
+    throw new ExitError(ExitCodes.CompileError);
   }
   const preValidationWarnCount = app.logger.warningCount;
   app.validate(project);
   const hadValidationWarnings =
     app.logger.warningCount !== preValidationWarnCount;
   if (app.logger.hasErrors()) {
-    return ExitCodes.ValidationError;
+    throw new ExitError(ExitCodes.ValidationError);
   }
   if (
     hadValidationWarnings &&
     (app.options.getValue("treatWarningsAsErrors") ||
       app.options.getValue("treatValidationWarningsAsErrors"))
   ) {
-    return ExitCodes.ValidationError;
+    throw new ExitError(ExitCodes.ValidationError);
   }
 
   const basePath = app.options.getValue("basePath");
   const converter = new Converter(project, basePath, config, symbolToType);
   converter.computePaths();
-  const space = app.options.getValue("pretty") ? "\t" : "";
   const result = converter.convertAll();
   await config.postConvert?.(app, project, converter.typedocToIRMap);
-  const res = JSON.stringify([result, app.extraData], null, space);
-  const json = app.options.getValue("json");
-  await writeFile(json, res);
-  app.logger.info(`JSON written to ${json}`);
-  app.logger.verbose(`JSON rendering took ${Date.now() - start}ms`);
+  return [app, result];
 }
-
-process.exit(await main());

--- a/sphinx_js/js/cli.ts
+++ b/sphinx_js/js/cli.ts
@@ -54,7 +54,9 @@ async function loadConfig(
   return configModule.config;
 }
 
-export async function run(args: string[]): Promise<[Application, TopLevelIR[]]> {
+export async function run(
+  args: string[],
+): Promise<[Application, TopLevelIR[]]> {
   // Most of this stuff is copied from typedoc/src/lib/cli.ts
   let app = await bootstrapAppTypedoc0_25(args);
   if (app.options.getValue("version")) {

--- a/sphinx_js/js/main.ts
+++ b/sphinx_js/js/main.ts
@@ -7,7 +7,7 @@ async function main() {
   let app, result;
   try {
     [app, result] = await run(args);
-  } catch(e) {
+  } catch (e) {
     if (e instanceof ExitError) {
       return e.code;
     }

--- a/sphinx_js/js/main.ts
+++ b/sphinx_js/js/main.ts
@@ -1,0 +1,25 @@
+import { writeFile } from "fs/promises";
+import { ExitError, run } from "./cli.ts";
+
+async function main() {
+  const start = Date.now();
+  const args = process.argv.slice(2);
+  let app, result;
+  try {
+    [app, result] = await run(args);
+  } catch(e) {
+    if (e instanceof ExitError) {
+      return e.code;
+    }
+    throw e;
+  }
+  const space = app.options.getValue("pretty") ? "\t" : "";
+  const res = JSON.stringify([result, app.extraData], null, space);
+  const json = app.options.getValue("json");
+  await writeFile(json, res);
+  app.logger.info(`JSON written to ${json}`);
+  app.logger.verbose(`JSON rendering took ${Date.now() - start}ms`);
+  return 0;
+}
+
+process.exit(await main());

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -71,7 +71,7 @@ def typedoc_output(
     dir = Path(__file__).parent.resolve() / "js"
     command.add("--tsconfig", str(dir / "tsconfig.json"))
     command.add("--import", str(dir / "registerImportHook.mjs"))
-    command.add(str(dir / "call_typedoc.ts"))
+    command.add(str(dir / "main.ts"))
     if ts_sphinx_js_config:
         command.add("--sphinxJsConfig", ts_sphinx_js_config)
     command.add("--entryPointStrategy", "expand")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -108,7 +108,7 @@ def test_global_install(tmp_path_factory, monkeypatch):
             "tsx@4.15.8",
             "--import",
             dir / "registerImportHook.mjs",
-            dir / "call_typedoc.ts",
+            dir / "main.ts",
             "--version",
         ],
         capture_output=True,


### PR DESCRIPTION
This moves most of the logic from call_typedoc.ts into a separate file called `cli.ts` which avoids some of the io like `process.exit()` and serializing json / writing to a file. Intended to help with testing.