### PR TITLE
Add some typescript tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - name: Update pip and install dev requirements
         run: |
           python -m pip install --upgrade pip
@@ -65,6 +60,11 @@ jobs:
     name: Python ${{ matrix.python-version}} + typedoc ${{ matrix.typedoc-version }}
     steps:
       - uses: actions/checkout@v3.1.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Set up Python
         uses: actions/setup-python@v4.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Update pip and install dev requirements
         run: |
           python -m pip install --upgrade pip
           pip install nox
+
       - name: Test
         run: nox -s tests-${{ matrix.python-version }}
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import nox
 from nox.sessions import Session
 
+PROJECT_ROOT = Path(__file__).parent
+
 
 @nox.session(python=["3.10", "3.11", "3.12", "3.13"])
 def tests(session: Session) -> None:
@@ -43,8 +45,18 @@ def test_typedoc(session: Session, typedoc: str) -> None:
         session.run("npx", "tsc", "--version", external=True)
         session.run("npx", "typedoc", "--version", external=True)
         # Run typescript tests
-        test_file = (Path(__file__).parent / "tests/test.ts").resolve()
-        session.run("npx", "--import", "tsx", "--test", test_file, external=True)
+        test_file = (PROJECT_ROOT / "tests/test.ts").resolve()
+        register_import_hook = PROJECT_ROOT / "sphinx_js/js/registerImportHook.mjs"
+        session.run(
+            "npx",
+            "--import",
+            register_import_hook,
+            "--import",
+            "tsx",
+            "--test",
+            test_file,
+            external=True,
+        )
     # Run Python tests
     session.run("pytest", "--junitxml=test-results.xml", "-k", "not js")
 

--- a/sphinx_js/js/importHooks.mjs
+++ b/sphinx_js/js/importHooks.mjs
@@ -18,6 +18,7 @@ export async function resolve(specifier, context, nextResolve) {
   for (const parentURL of [origURL, fallbackURL]) {
     context.parentURL = parentURL;
     const res = await tryResolve(specifier, context, nextResolve);
+    context.parentURL = origURL;
     if (res) {
       return res;
     }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert";
+import { test, suite, before } from "node:test";
+import { run } from "../sphinx_js/js/cli";
+import { TopLevelIR, Type } from "../sphinx_js/js/ir";
+import { Application } from "typedoc";
+
+function joinType(t: Type): string {
+  return t.map((x) => (typeof x === "string" ? x : x.name)).join("");
+}
+
+function resolveFile(path: string): string {
+  return import.meta.dirname + "/" + path;
+}
+
+suite("types.ts", async () => {
+  let app: Application;
+  let results: TopLevelIR[];
+  let map: Map<string, TopLevelIR>;
+  before(async () => {
+    [app, results] = await run([
+      "--sphinxJsConfig",
+      resolveFile("sphinxJsConfig.ts"),
+      "--entryPointStrategy",
+      "expand",
+      "--tsconfig",
+      resolveFile("test_typedoc_analysis/source/tsconfig.json"),
+      "--basePath",
+      resolveFile("test_typedoc_analysis/source"),
+      resolveFile("test_typedoc_analysis/source/types.ts"),
+    ]);
+    map = new Map(results.map((res) => [res.name, res]));
+  });
+  function getObject(name: string): TopLevelIR {
+    const obj = map.get(name);
+    assert(obj);
+    return obj;
+  }
+  suite("basic", async () => {
+    for (const [obj_name, type_name] of [
+      ["bool", "boolean"],
+      ["num", "number"],
+      ["str", "string"],
+      ["array", "number[]"],
+      ["genericArray", "number[]"],
+      ["tuple", "[string, number]"],
+      ["color", "Color"],
+      ["unk", "unknown"],
+      ["whatever", "any"],
+      ["voidy", "void"],
+      ["undef", "undefined"],
+      ["nully", "null"],
+      ["nev", "never"],
+      ["obj", "object"],
+      ["sym", "symbol"],
+    ]) {
+      await test(obj_name, () => {
+        const obj = getObject(obj_name);
+        assert.strictEqual(obj.kind, "attribute");
+        assert.strictEqual(joinType(obj.type), type_name);
+      });
+    }
+  });
+  await test("named_interface", () => {
+    const obj = getObject("interfacer");
+    assert.strictEqual(obj.kind, "function");
+    assert.deepStrictEqual(obj.params[0].type, [
+      {
+        name: "Interface",
+        path: ["./", "types.", "Interface"],
+        type: "internal",
+      },
+    ]);
+  });
+  await test("interface_readonly_member", () => {
+    const obj = getObject("Interface");
+    assert.strictEqual(obj.kind, "interface");
+    const readOnlyNum = obj.members[0];
+    assert.strictEqual(readOnlyNum.kind, "attribute");
+    assert.strictEqual(readOnlyNum.name, "readOnlyNum");
+    assert.deepStrictEqual(readOnlyNum.type, [
+      { name: "number", type: "intrinsic" },
+    ]);
+  });
+  await test("array", () => {
+    const obj = getObject("overload");
+    assert.strictEqual(obj.kind, "function");
+    assert.deepStrictEqual(obj.params[0].type, [
+      { name: "string", type: "intrinsic" },
+      "[]",
+    ]);
+  });
+  await test("literal_types", () => {
+    const obj = getObject("certainNumbers");
+    assert.strictEqual(obj.kind, "attribute");
+    assert.deepStrictEqual(obj.type, [
+      {
+        name: "CertainNumbers",
+        path: ["./", "types.", "CertainNumbers"],
+        type: "internal",
+      },
+    ]);
+  });
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -37,7 +37,7 @@ suite("types.ts", async () => {
   }
   suite("basic", async () => {
     for (const [obj_name, type_name] of [
-      ["bool", "boolean1"],
+      ["bool", "boolean"],
       ["num", "number"],
       ["str", "string"],
       ["array", "number[]"],

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -33,11 +33,11 @@ suite("types.ts", async () => {
   function getObject(name: string): TopLevelIR {
     const obj = map.get(name);
     assert(obj);
-    return obj;
+    return obj!;
   }
   suite("basic", async () => {
     for (const [obj_name, type_name] of [
-      ["bool", "boolean"],
+      ["bool", "boolean1"],
       ["num", "number"],
       ["str", "string"],
       ["array", "number[]"],


### PR DESCRIPTION
So far these more or less duplicate a subset of the tests in `test_typedoc_analysis` so they don't provide that much added value because they are still basically integration tests with respect to the typescript logic. But this is a first step and will allow finer grained typescript tests in the future.