### PR TITLE
Use file and name as key for private type aliases

### DIFF
--- a/sphinx_js/js/convertType.ts
+++ b/sphinx_js/js/convertType.ts
@@ -233,7 +233,10 @@ class TypeConverter implements TypeVisitor<Type> {
       throw new Error("This should not happen");
     }
     // See if this refers to a private type. In that case we should inline the
-    // type reflection rather than referring to the non-exported name.
+    // type reflection rather than referring to the non-exported name. Ideally
+    // we should key on position rather than name (the same file can have
+    // multiple private types with the same name potentially). But it doesn't
+    // seem to be working.
     const newTarget = this.symbolToType.get(
       `${type.symbolId.fileName}:${type.name}`,
     );

--- a/sphinx_js/js/convertType.ts
+++ b/sphinx_js/js/convertType.ts
@@ -235,7 +235,7 @@ class TypeConverter implements TypeVisitor<Type> {
     // See if this refers to a private type. In that case we should inline the
     // type reflection rather than referring to the non-exported name.
     const newTarget = this.symbolToType.get(
-      `${type.symbolId.fileName}:${type.symbolId.pos}`,
+      `${type.symbolId.fileName}:${type.name}`,
     );
     if (newTarget) {
       // TODO: this doesn't handle parentheses correctly.

--- a/sphinx_js/js/redirectPrivateAliases.ts
+++ b/sphinx_js/js/redirectPrivateAliases.ts
@@ -101,7 +101,7 @@ export function redirectPrivateTypes(app: Application): ReadonlySymbolToType {
     const referenced = getReferencedSymbols(owningModule);
     return Array.from(referenced).filter((s) => {
       const refl = context.project.getReflectionFromSymbol(s);
-      return !refl || refl.flags.isPrivate;
+      return !refl || refl.flags.isPrivate || refl?.comment?.modifierTags.has("@hidden");
     });
   }
 
@@ -141,15 +141,9 @@ export function redirectPrivateTypes(app: Application): ReadonlySymbolToType {
         if (ts.isTypeAliasDeclaration(decl)) {
           const sf = decl.getSourceFile();
           const fileName = sf.fileName;
-          const pos = Application.VERSION.startsWith("0.25")
-            ? decl.pos
-            : decl.getStart();
           const converted = context.converter.convertType(context, decl.type);
-          // Depending on whether we have a symbolId or a reflection in
-          // renderType we'll use different keys to look this up.
-          symbolToType.set(`${fileName}:${pos}`, converted);
           // Ideally we should be able to key on position rather than file and
-          // name when the reflection is present but I couldn't figure out how.
+          // name but I couldn't figure out how.
           symbolToType.set(`${fileName}:${decl.name.getText()}`, converted);
         }
       }

--- a/sphinx_js/js/redirectPrivateAliases.ts
+++ b/sphinx_js/js/redirectPrivateAliases.ts
@@ -101,7 +101,11 @@ export function redirectPrivateTypes(app: Application): ReadonlySymbolToType {
     const referenced = getReferencedSymbols(owningModule);
     return Array.from(referenced).filter((s) => {
       const refl = context.project.getReflectionFromSymbol(s);
-      return !refl || refl.flags.isPrivate || refl?.comment?.modifierTags.has("@hidden");
+      return (
+        !refl ||
+        refl.flags.isPrivate ||
+        refl?.comment?.modifierTags.has("@hidden")
+      );
     });
   }
 


### PR DESCRIPTION
It's probably better to use the position as the key but since 0.26.0 it doesn't seem to work correctly. This also redirects aliases that are marked as `@hidden`